### PR TITLE
fix to avoid occasional overflow in minor gas code when using single …

### DIFF
--- a/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
@@ -447,7 +447,8 @@ contains
                 if (scale_by_complement(imnr)) then ! scale by densities of all gases but the special one
                   scaling = scaling * (1._wp - mycol_gas_imnr * vmr_fact * dry_fact)
                 else
-                  scaling = scaling *          mycol_gas_imnr * vmr_fact * dry_fact
+                 !scaling = scaling *          mycol_gas_imnr * vmr_fact * dry_fact
+                  scaling = scaling *          (mycol_gas_imnr * vmr_fact * dry_fact)
                 endif
               endif
             endif

--- a/rrtmgp/kernels/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels/mo_gas_optics_kernels.F90
@@ -404,7 +404,8 @@ contains
                   if (scale_by_complement(imnr)) then ! scale by densities of all gases but the special one
                     scaling = scaling * (1._wp - col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact)
                   else
-                    scaling = scaling *          col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact
+                  ! scaling = scaling *          col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact
+                    scaling = scaling *          (col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact)
                   endif
                 endif
               endif

--- a/rrtmgp/mo_gas_concentrations.F90
+++ b/rrtmgp/mo_gas_concentrations.F90
@@ -477,6 +477,7 @@ contains
     ! -----------------
     find_gas = GAS_NOT_IN_LIST
     if(.not. allocated(this%gas_name)) return
+    ! search gases using a loop. Fortran intrinsic findloc would be faster, but only supported since gfortran 9
     do igas = 1, size(this%gas_name)
       if (lower_case(trim(this%gas_name(igas))) == lower_case(trim(gas))) then
         find_gas = igas


### PR DESCRIPTION
…precision. Also add comment pointing out findloc would be faster in find_gas, but this is a Fortran 2008 feature only supported since gfortran 9.0.