### PR TITLE
New finalize functions in ty_optical_props.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -130,6 +130,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Environmental variables
+      run: |
         echo "RRTMGP_ROOT=${GITHUB_WORKSPACE}"        >> $GITHUB_ENV
         echo "RRTMGP_BUILD=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
       if: contains(matrix.fortran-compiler, 'gfortran-10')
       run: |
         sudo apt-get install gfortran-10 gcc-10
-        echo "::set-env name=CC::gcc-10"
+        echo "CC=gcc-10" >> $GITHUB_ENV
     #
     # Intel compilers and libraries if needed
     #   https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html#aptpkg
@@ -46,9 +46,9 @@ jobs:
         sudo apt-get install intel-oneapi-common-licensing intel-oneapi-common-vars
         sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-dpcpp-cpp-compiler-pro
         sudo apt-get install intel-oneapi-ifort intel-oneapi-inspector intel-oneapi-itac
-        echo "::set-env name=FC::ifort"
-        echo "::set-env name=CC::icx"
-        echo "::set-env name=FCFLAGS::-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+        echo "FC=fort" >> $GITHUB_ENV
+        echo "CC=icx"  >> $GITHUB_ENV
+        echo "FCFLAGS='-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08'" >> $GITHUB_ENV
 
     # Caching cribbed from https://github.com/NCAR/ParallelIO/blob/3a77973ad5e09d354257045bf3d53827ae36a86b/.github/workflows/a3.yml#L1
     - name: cache-nvidia-compilers
@@ -73,10 +73,10 @@ jobs:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
       if: contains(matrix.fortran-compiler, 'nvfortran')
       run: |
-        echo "::set-env name=FC::nvfortran"
-        echo "::set-env name=CC::nvc"
-        echo "::set-env name=FCFLAGS::-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
-        echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"
+        echo "FC=nvfortran" >> $GITHUB_ENV
+        echo "CC=nvc"       >> $GITHUB_ENV
+        echo "FCFLAGS='-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk'" >> $GITHUB_ENV
+        echo "${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin" >> $GITHUB_PATH
     ############################################################################
     # Netcdf C and Fortran
     #

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
         sudo apt-get install intel-oneapi-ifort intel-oneapi-inspector intel-oneapi-itac
         echo "FC=fort" >> $GITHUB_ENV
         echo "CC=icx"  >> $GITHUB_ENV
-        echo "FCFLAGS='-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08'" >> $GITHUB_ENV
+        echo "FCFLAGS=-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08" >> $GITHUB_ENV
 
     # Caching cribbed from https://github.com/NCAR/ParallelIO/blob/3a77973ad5e09d354257045bf3d53827ae36a86b/.github/workflows/a3.yml#L1
     - name: cache-nvidia-compilers
@@ -75,7 +75,7 @@ jobs:
       run: |
         echo "FC=nvfortran" >> $GITHUB_ENV
         echo "CC=nvc"       >> $GITHUB_ENV
-        echo "FCFLAGS='-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk'" >> $GITHUB_ENV
+        echo "FCFLAGS=-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk" >> $GITHUB_ENV
         echo "${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin" >> $GITHUB_PATH
     ############################################################################
     # Netcdf C and Fortran

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler:  [gfortran-8, gfortran-9, ifort, nvfortran]
+        fortran-compiler:  [gfortran-8, gfortran-9, nvfortran]
         # I'd like to add gfortran-10 to this list but have version issues with netcdf as below
         rte-kernels: [default, openacc]
     env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -129,14 +129,16 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Environmental variables
+        echo "RRTMGP_ROOT=${GITHUB_WORKSPACE}"        >> $GITHUB_ENV
+        echo "RRTMGP_BUILD=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
+
     - name: Make library, examples, tests
       env:
         RTE_KERNELS: ${{ matrix.rte-kernels }}
       run: |
-        echo "RRTMGP_ROOT=${GITHUB_WORKSPACE}"        >> $GITHUB_ENV
-        echo "RRTMGP_BUILD=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
         source /opt/intel/oneapi/setvars.sh || true
-        cd ${GITHUB_WORKSPACE}
+        cd ${RRTMGP_ROOT}
         ${FC} --version
         make -C build -j 2
         make -C tests -j 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler:  [gfortran-8, gfortran-9, nvfortran]
+        fortran-compiler:  [gfortran-8, gfortran-9, ifort, nvfortran]
         # I'd like to add gfortran-10 to this list but have version issues with netcdf as below
         rte-kernels: [default, openacc]
     env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,11 +133,10 @@ jobs:
       env:
         RTE_KERNELS: ${{ matrix.rte-kernels }}
       run: |
-        echo "::set-env name=RRTMGP_ROOT::${GITHUB_WORKSPACE}"
-        export RRTMGP_ROOT=${GITHUB_WORKSPACE}
-        export RRTMGP_BUILD=${RRTMGP_ROOT}/build
+        echo "RRTMGP_ROOT=${GITHUB_WORKSPACE}"        >> $GITHUB_ENV
+        echo "RRTMGP_BUILD=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
         source /opt/intel/oneapi/setvars.sh || true
-        cd ${RRTMGP_ROOT}
+        cd ${GITHUB_WORKSPACE}
         ${FC} --version
         make -C build -j 2
         make -C tests -j 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get install intel-oneapi-common-licensing intel-oneapi-common-vars
         sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-dpcpp-cpp-compiler-pro
         sudo apt-get install intel-oneapi-ifort intel-oneapi-inspector intel-oneapi-itac
-        echo "FC=fort" >> $GITHUB_ENV
+        echo "FC=ifort" >> $GITHUB_ENV
         echo "CC=icx"  >> $GITHUB_ENV
         echo "FCFLAGS=-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08" >> $GITHUB_ENV
 

--- a/rte/mo_optical_props.F90
+++ b/rte/mo_optical_props.F90
@@ -163,6 +163,7 @@ module mo_optical_props
     procedure, public  :: validate => validate_1scalar
     procedure, public  :: get_subset => subset_1scl_range
     procedure, public  :: delta_scale => delta_scale_1scl
+    procedure, public  :: finalize => finalize_1scl
 
     procedure, private :: alloc_only_1scl
     procedure, private :: init_and_alloc_1scl
@@ -178,6 +179,7 @@ module mo_optical_props
     procedure, public  :: validate => validate_2stream
     procedure, public  :: get_subset => subset_2str_range
     procedure, public  :: delta_scale => delta_scale_2str
+    procedure, public  :: finalize => finalize_2str
 
     procedure, private :: alloc_only_2str
     procedure, private :: init_and_alloc_2str
@@ -194,6 +196,7 @@ module mo_optical_props
     procedure, public :: get_subset => subset_nstr_range
     procedure, public :: delta_scale => delta_scale_nstr
     procedure, public :: get_nmom
+    procedure, public :: finalize => finalize_nstr
 
     procedure, private :: alloc_only_nstr
     procedure, private :: init_and_alloc_nstr
@@ -482,6 +485,35 @@ contains
     if(err_message /= "") return
     err_message = this%alloc_nstr(nmom, ncol, nlay)
   end function copy_and_alloc_nstr
+  ! ------------------------------------------------------------------------------------------
+  !
+  ! Finalize routines
+  !
+  ! ------------------------------------------------------------------------------------------
+  subroutine finalize_1scl(this)
+    class(ty_optical_props_1scl), intent(inout) :: this
+    
+    if(allocated(this%tau)) deallocate(this%tau)    
+    this%name = ""
+  end subroutine finalize_1scl
+  ! ---------------------------------------------------------------------------
+  subroutine finalize_2str(this)
+    class(ty_optical_props_2str), intent(inout)  :: this
+    
+    if(allocated(this%tau)) deallocate(this%tau)    
+    if(allocated(this%ssa)) deallocate(this%ssa)    
+    if(allocated(this%g  )) deallocate(this%g  )    
+    this%name = ""
+  end subroutine finalize_2str
+  ! ---------------------------------------------------------------------------
+  subroutine finalize_nstr(this)
+    class(ty_optical_props_nstr), intent(inout)  :: this
+    
+    if(allocated(this%tau)) deallocate(this%tau)    
+    if(allocated(this%ssa)) deallocate(this%ssa)    
+    if(allocated(this%p  )) deallocate(this%p  )    
+    this%name = ""
+  end subroutine finalize_nstr  
   ! ------------------------------------------------------------------------------------------
   !
   !  Routines for array classes: delta-scaling, validation (ensuring all values can be used )

--- a/rte/mo_optical_props.F90
+++ b/rte/mo_optical_props.F90
@@ -163,7 +163,7 @@ module mo_optical_props
     procedure, public  :: validate => validate_1scalar
     procedure, public  :: get_subset => subset_1scl_range
     procedure, public  :: delta_scale => delta_scale_1scl
-    procedure, public  :: finalize => finalize_1scl
+    procedure, public  :: finalize_1scl
 
     procedure, private :: alloc_only_1scl
     procedure, private :: init_and_alloc_1scl
@@ -179,7 +179,7 @@ module mo_optical_props
     procedure, public  :: validate => validate_2stream
     procedure, public  :: get_subset => subset_2str_range
     procedure, public  :: delta_scale => delta_scale_2str
-    procedure, public  :: finalize => finalize_2str
+    procedure, public  :: finalize_2str
 
     procedure, private :: alloc_only_2str
     procedure, private :: init_and_alloc_2str
@@ -196,7 +196,7 @@ module mo_optical_props
     procedure, public :: get_subset => subset_nstr_range
     procedure, public :: delta_scale => delta_scale_nstr
     procedure, public :: get_nmom
-    procedure, public :: finalize => finalize_nstr
+    procedure, public :: finalize_nstr
 
     procedure, private :: alloc_only_nstr
     procedure, private :: init_and_alloc_nstr
@@ -490,30 +490,33 @@ contains
   ! Finalize routines
   !
   ! ------------------------------------------------------------------------------------------
-  subroutine finalize_1scl(this)
-    class(ty_optical_props_1scl), intent(inout) :: this
-    
+  function finalize_1scl(this) result(err_message)
+    class(ty_optical_props_1scl) :: this
+    character(len=128)           :: err_message
+
     if(allocated(this%tau)) deallocate(this%tau)    
-    this%name = ""
-  end subroutine finalize_1scl
+    err_message = ""
+  end function finalize_1scl
   ! ---------------------------------------------------------------------------
-  subroutine finalize_2str(this)
-    class(ty_optical_props_2str), intent(inout)  :: this
+  function finalize_2str(this) result(err_message)
+    class(ty_optical_props_2str) :: this
+    character(len=128)           :: err_message
     
     if(allocated(this%tau)) deallocate(this%tau)    
     if(allocated(this%ssa)) deallocate(this%ssa)    
     if(allocated(this%g  )) deallocate(this%g  )    
-    this%name = ""
-  end subroutine finalize_2str
+    err_message = ""
+  end function finalize_2str
   ! ---------------------------------------------------------------------------
-  subroutine finalize_nstr(this)
-    class(ty_optical_props_nstr), intent(inout)  :: this
+  function finalize_nstr(this) result(err_message)
+    class(ty_optical_props_nstr) :: this
+    character(len=128)           :: err_message
     
     if(allocated(this%tau)) deallocate(this%tau)    
     if(allocated(this%ssa)) deallocate(this%ssa)    
     if(allocated(this%p  )) deallocate(this%p  )    
-    this%name = ""
-  end subroutine finalize_nstr  
+    err_message = ""
+  end function finalize_nstr 
   ! ------------------------------------------------------------------------------------------
   !
   !  Routines for array classes: delta-scaling, validation (ensuring all values can be used )


### PR DESCRIPTION
This PR contains three new functions in the ty_optical_props class. 
In mo_optical_props.F90, finalize_1scl, finalize_2str, and finalize_nstr were added to the ty_optical_props_1scl, ty_optical_props_2str, and ty_optical_props_nstr, respectively.

There are some additional modifications of the continuous integration testing from @RobertPincus 