### PR TITLE
oneapi package name change

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   CI:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         fortran-compiler:  [gfortran-8, gfortran-9, ifort, nvfortran]
@@ -44,8 +44,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install intel-hpckit-getting-started intel-oneapi-clck
         sudo apt-get install intel-oneapi-common-licensing intel-oneapi-common-vars
-        sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-dpcpp-cpp-compiler-pro
-        sudo apt-get install intel-oneapi-ifort intel-oneapi-inspector intel-oneapi-itac
+        sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-inspector intel-oneapi-itac
         echo "FC=ifort" >> $GITHUB_ENV
         echo "CC=icx"  >> $GITHUB_ENV
         echo "FCFLAGS=-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,7 +66,7 @@ jobs:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
       if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
       run: |
-        wget https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-11_20.11_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.11_amd64.deb
+        wget https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc-20-11_20.11_amd64.deb https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc-2020_20.11_amd64.deb
         sudo apt-get install ./nvhpc-20-7_20.11_amd64.deb ./nvhpc-2020_20.11_amd64.deb
     - name: Nvidia environment
       env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,8 +66,8 @@ jobs:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
       if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
       run: |
-        wget https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc-20-11_20.11_amd64.deb https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc-2020_20.11_amd64.deb
-        sudo apt-get install ./nvhpc-20-7_20.11_amd64.deb ./nvhpc-2020_20.11_amd64.deb
+        wget -q https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc-20-11_20.11_amd64.deb https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc-2020_20.11_amd64.deb
+        sudo apt-get install ./nvhpc-20-11_20.11_amd64.deb ./nvhpc-2020_20.11_amd64.deb
     - name: Nvidia environment
       env:
         NVCOMPILERS: /opt/nvidia/hpc_sdk

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,7 +66,7 @@ jobs:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
       if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
       run: |
-        wget https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-11_20.11_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
+        wget https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-11_20.11_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.11_amd64.deb
         sudo apt-get install ./nvhpc-20-7_20.11_amd64.deb ./nvhpc-2020_20.11_amd64.deb
     - name: Nvidia environment
       env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/nvidia/hpc_sdk/
-        key: nvhpc-${{ runner.os }}-2020-20.7
+        key: nvhpc-${{ runner.os }}-2020-20.11
     #
     # Nvidia compilers
     #
@@ -66,8 +66,8 @@ jobs:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
       if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
       run: |
-        wget -q https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-7_20.7_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
-        sudo apt-get install ./nvhpc-20-7_20.7_amd64.deb ./nvhpc-2020_20.7_amd64.deb
+        wget https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-11_20.11_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
+        sudo apt-get install ./nvhpc-20-7_20.11_amd64.deb ./nvhpc-2020_20.11_amd64.deb
     - name: Nvidia environment
       env:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
@@ -76,7 +76,7 @@ jobs:
         echo "FC=nvfortran" >> $GITHUB_ENV
         echo "CC=nvc"       >> $GITHUB_ENV
         echo "FCFLAGS=-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk" >> $GITHUB_ENV
-        echo "${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin" >> $GITHUB_PATH
+        echo "${NVCOMPILERS}/Linux_x86_64/20.11/compilers/bin" >> $GITHUB_PATH
     ############################################################################
     # Netcdf C and Fortran
     #


### PR DESCRIPTION
Uses latest package names for ifort and icc. Latest ifort requires ubuntu 20.04 to avoid linker issue