### PR TITLE
OpenMP GPU fixes for the Cray 11.x compiler

### DIFF
--- a/rrtmgp/mo_gas_concentrations.F90
+++ b/rrtmgp/mo_gas_concentrations.F90
@@ -107,6 +107,7 @@ contains
     allocate(this%gas_name(ngas), this%concs(ngas))
     !$acc enter data copyin(this)
     !$acc enter data copyin(this%concs)
+    !$omp target enter data map(to:this%concs)
 
     this%gas_name(:) = gas_names(:)
   end function
@@ -520,7 +521,7 @@ contains
         end if
       end do
       !$acc exit data delete(this%concs)
-      !!$omp target exit data map(release:this%concs) ! Not needed with Cray compiler
+      !$omp target exit data map(release:this%concs)
       deallocate(this%concs)
     end if
   end subroutine reset

--- a/rrtmgp/mo_gas_concentrations.F90
+++ b/rrtmgp/mo_gas_concentrations.F90
@@ -520,7 +520,7 @@ contains
         end if
       end do
       !$acc exit data delete(this%concs)
-      !$omp target exit data map(release:this%concs)
+      !!$omp target exit data map(release:this%concs) ! Not needed with Cray compiler
       deallocate(this%concs)
     end if
   end subroutine reset

--- a/rrtmgp/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp/mo_gas_optics_rrtmgp.F90
@@ -1484,6 +1484,7 @@ contains
     ! column transmissivity
     !
     !$acc parallel loop gang vector collapse(2) copyin(optical_props, optical_props%tau, optical_props%gpt2band) copyout(optimal_angles)
+    !$omp target teams distribute parallel do simd collapse(2) map(to: optical_props%tau, optical_props%gpt2band) map(from:optimal_angles)
     do icol = 1, ncol
       do igpt = 1, ngpt
         !

--- a/rrtmgp/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp/mo_gas_optics_rrtmgp.F90
@@ -1847,7 +1847,7 @@ contains
           call zero_array(     ncol,nlay,ngpt,optical_props%ssa)
           call zero_array(     ncol,nlay,ngpt,optical_props%g  )
           !$acc exit data copyout(optical_props%ssa, optical_props%g)
-          !$omp target exit data map(from:optical_props%ssa, optical_props%g)
+          !!$omp target exit data map(from:optical_props%ssa, optical_props%g) ! Not needed with Cray compiler
         type is (ty_optical_props_nstr) ! We ought to be able to combine this with above
           nmom = size(optical_props%p, 1)
           !$acc enter data create(optical_props%ssa, optical_props%p)

--- a/rrtmgp/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp/mo_gas_optics_rrtmgp.F90
@@ -1843,7 +1843,7 @@ contains
       select type(optical_props)
         type is (ty_optical_props_2str)
           !$acc enter data create(optical_props%ssa, optical_props%g)
-          !$omp target enter data map(alloc:optical_props%ssa, optical_props%g)
+          !!$omp target enter data map(alloc:optical_props%ssa, optical_props%g) ! Not needed with Cray compiler
           call zero_array(     ncol,nlay,ngpt,optical_props%ssa)
           call zero_array(     ncol,nlay,ngpt,optical_props%g  )
           !$acc exit data copyout(optical_props%ssa, optical_props%g)

--- a/rte/kernels-openacc/mo_optical_props_kernels.F90
+++ b/rte/kernels-openacc/mo_optical_props_kernels.F90
@@ -900,8 +900,8 @@ contains
     !$acc&     copyout(array_out(:cole-cols+1,:nlay,:ngpt)) &
     !$acc&     copyin(array_in(cols:cole,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(from:array_out(:cole-cols+1, :nlay, :ngpt)) &
-    !$omp& map(to:array_in(cols:cole, :nlay, :ngpt))
+    !$omp& map(from:array_out) &
+    !$omp& map(to:array_in)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = colS, colE
@@ -926,8 +926,8 @@ contains
     !$acc&     copyout(array_out(:nmom,:cole-cols+1,:nlay,:ngpt)) &
     !$acc&     copyin(array_in(:nmom,cols:cole,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(4) &
-    !$omp& map(from:array_out(:nmom, :cole-cols+1, :nlay, :ngpt)) &
-    !$omp& map(to:array_in(:nmom, cols:cole, :nlay, :ngpt))
+    !$omp& map(from:array_out) &
+    !$omp& map(to:array_in)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = colS, colE
@@ -959,9 +959,9 @@ contains
     !$acc&     copyout(tau_out(:cole-cols+1,:nlay,:ngpt)) &
     !$acc&     copyin(tau_in(cols:cole,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:ssa_in(cols:cole, :nlay, :ngpt)) &
-    !$omp& map(from:tau_out(:cole-cols+1, :nlay, :ngpt)) &
-    !$omp& map(to:tau_in(cols:cole, :nlay, :ngpt))
+    !$omp& map(to:ssa_in) &
+    !$omp& map(from:tau_out) &
+    !$omp& map(to:tau_in)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = colS, colE


### PR DESCRIPTION
These commits enable the clear_sky_regression test to run correctly with Cray 11.x compiler with the NVidia V100 backend. Untested on the P100.