### PR TITLE
Improvements to make more comformant to OpenMP spec

### DIFF
--- a/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
@@ -900,9 +900,9 @@ contains
   ! compilers which do not support GPU versions
   !
   subroutine minmaxloc(i, mask, a, minl, maxl)
+    implicit none
     !$acc routine seq
     !$omp declare target
-    implicit none
     integer :: i, minl, maxl
     logical(wl) :: mask(:,:)
     real(wp) :: a(:,:)

--- a/rte/kernels-openacc/mo_optical_props_kernels.F90
+++ b/rte/kernels-openacc/mo_optical_props_kernels.F90
@@ -64,9 +64,9 @@ contains
     !$acc&     copyin(f(:ncol,:nlay,:ngpt)) &
     !$acc&     copy(g(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:ssa(:ncol, :nlay, :ngpt), tau(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:f(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:g(:ncol, :nlay, :ngpt))
+    !$omp& map(tofrom:ssa, tau) &
+    !$omp& map(to:f) &
+    !$omp& map(tofrom:g)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -97,7 +97,7 @@ contains
     !$acc  parallel loop collapse(3) &
     !$acc&     copy(tau(:ncol,:nlay,:ngpt),ssa(:ncol,:nlay,:ngpt),g(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:tau(:ncol, :nlay, :ngpt), ssa(:ncol, :nlay, :ngpt), g(:ncol, :nlay, :ngpt))
+    !$omp& map(tofrom:tau, ssa, g)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -144,8 +144,8 @@ contains
     !$acc&     copyin(tau2(:ncol,:nlay,:ngpt)) &
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt))
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:tau1)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -172,9 +172,9 @@ contains
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(ssa2(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :ngpt))
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:ssa2)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -202,9 +202,9 @@ contains
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(ssa2(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :ngpt))
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:ssa2)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -234,9 +234,9 @@ contains
     !$acc&     copyin(tau2(:ncol,:nlay,:ngpt)) &
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt))
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:tau1)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -270,10 +270,10 @@ contains
     !$acc&     copyin(ssa2(:ncol,:nlay,:ngpt),tau2(:ncol,:nlay,:ngpt)) &
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt),g1(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:g2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :ngpt), tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt), g1(:ncol, :nlay, :ngpt))
+    !$omp& map(to:g2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:ssa2, tau2) &
+    !$omp& map(tofrom:tau1, g1)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -316,10 +316,10 @@ contains
     !$acc&     copyin(ssa2(:ncol,:nlay,:ngpt),tau2(:ncol,:nlay,:ngpt)) &
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt),g1(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:p2(:1, :ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :ngpt), tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt), g1(:ncol, :nlay, :ngpt))
+    !$omp& map(to:p2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:ssa2, tau2) &
+    !$omp& map(tofrom:tau1, g1)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -360,9 +360,9 @@ contains
     !$acc&     copyin(tau2(:ncol,:nlay,:ngpt)) &
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt))
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:tau1)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -402,12 +402,12 @@ contains
     !$acc&     private(temp_moms) &
     !$acc&     copyin(tau2(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:p1(:nmom1, :ncol, :nlay, :ngpt), ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:g2(:ncol, :nlay, :ngpt)) &
+    !$omp& map(tofrom:p1, ssa1) &
+    !$omp& map(to:ssa2) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:g2) &
     !$omp& private(temp_moms) &
-    !$omp& map(to:tau2(:ncol, :nlay, :ngpt))
+    !$omp& map(to:tau2)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -458,10 +458,10 @@ contains
     !$acc&     copyin(ssa2(:ncol,:nlay,:ngpt),tau2(:ncol,:nlay,:ngpt)) &
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt),p1(:mom_lim,:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:p2(:mom_lim, :ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :ngpt), tau2(:ncol, :nlay, :ngpt)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt), p1(:mom_lim, :ncol, :nlay, :ngpt))
+    !$omp& map(to:p2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:ssa2, tau2) &
+    !$omp& map(tofrom:tau1, p1)
     do igpt = 1, ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -505,9 +505,9 @@ contains
     !$acc& copy(tau1(:ncol,:nlay,:ngpt)) &
     !$acc& copyin(gpt_lims(:,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:gpt_lims(:, :nbnd))
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:gpt_lims)
     do igpt = 1 , ngpt
       do ilay = 1 , nlay
         do icol = 1 , ncol
@@ -537,9 +537,9 @@ contains
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(gpt_lims(:,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd), ssa2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:gpt_lims(:, :nbnd))
+    !$omp& map(to:tau2, ssa2) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:gpt_lims)
     do igpt = 1 , ngpt
       do ilay = 1 , nlay
         do icol = 1 , ncol
@@ -569,9 +569,9 @@ contains
     !$acc&     copy(tau1(:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(ssa2(:ncol,:nlay,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:gpt_lims(:, :nbnd), tau2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :nbnd))
+    !$omp& map(to:gpt_lims, tau2) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:ssa2)
     do igpt = 1 , ngpt
       do ilay = 1 , nlay
         do icol = 1 , ncol
@@ -605,10 +605,10 @@ contains
     !$acc&     copy(ssa1(:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(gpt_lims(:,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:gpt_lims(:, :nbnd))
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:gpt_lims)
     do igpt = 1 , ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -645,12 +645,12 @@ contains
     !$acc&     copy(g1(:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(g2(:ncol,:nlay,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd), ssa2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:gpt_lims(:, :nbnd)) &
-    !$omp& map(tofrom:g1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:g2(:ncol, :nlay, :nbnd))
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:tau2, ssa2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:gpt_lims) &
+    !$omp& map(tofrom:g1) &
+    !$omp& map(to:g2)
     do igpt = 1 , ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -696,11 +696,11 @@ contains
     !$acc&     copyin(p2(:1,:ncol,:nlay,:nbnd),gpt_lims(:,:nbnd)) &
     !$acc&     copy(g1(:ncol,:nlay,:ngpt))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd), ssa2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:p2(:1, :ncol, :nlay, :nbnd), gpt_lims(:, :nbnd)) &
-    !$omp& map(tofrom:g1(:ncol, :nlay, :ngpt))
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:tau2, ssa2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:p2, gpt_lims) &
+    !$omp& map(tofrom:g1)
     do igpt = 1 , ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -744,10 +744,10 @@ contains
     !$acc&     copy(ssa1(:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(gpt_lims(:,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:gpt_lims(:, :nbnd))
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:gpt_lims)
     do igpt = 1 , ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -789,12 +789,12 @@ contains
     !$acc&     private(temp_moms) &
     !$acc&     copyin(gpt_lims(:,:nbnd),g2(:ncol,:nlay,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt), p1(:nmom1, :ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd)) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:ssa2) &
+    !$omp& map(tofrom:ssa1, p1) &
+    !$omp& map(to:tau2) &
     !$omp& private(temp_moms) &
-    !$omp& map(to:gpt_lims(:, :nbnd), g2(:ncol, :nlay, :nbnd))
+    !$omp& map(to:gpt_lims, g2)
     do igpt = 1 , ngpt
       do ilay = 1, nlay
         do icol = 1, ncol
@@ -850,13 +850,13 @@ contains
     !$acc&     copy(p1(:mom_lim,:ncol,:nlay,:ngpt)) &
     !$acc&     copyin(gpt_lims(:,:nbnd))
     !$omp target teams distribute parallel do simd collapse(3) &
-    !$omp& map(to:p2(:mom_lim, :ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:ssa1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:ssa2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:tau1(:ncol, :nlay, :ngpt)) &
-    !$omp& map(to:tau2(:ncol, :nlay, :nbnd)) &
-    !$omp& map(tofrom:p1(:mom_lim, :ncol, :nlay, :ngpt)) &
-    !$omp& map(to:gpt_lims(:, :nbnd))
+    !$omp& map(to:p2) &
+    !$omp& map(tofrom:ssa1) &
+    !$omp& map(to:ssa2) &
+    !$omp& map(tofrom:tau1) &
+    !$omp& map(to:tau2) &
+    !$omp& map(tofrom:p1) &
+    !$omp& map(to:gpt_lims)
     do igpt = 1 , ngpt
       do ilay = 1, nlay
         do icol = 1, ncol


### PR DESCRIPTION
The Intel oneAPI compiler (which supports the Intel GPU) has more strict compile-time checks for compliance with the latest OpenMP spec. The Cray compiler will actually compile the code that contains map clauses of discontiguous arrays, but will then emit a run-time error stating that it cannot map discontiguous arrays. 