### PR TITLE
Use in-house minmaxloc with NVidia's Fortran OpenMP compiler on the GPU

### DIFF
--- a/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
@@ -235,7 +235,7 @@ contains
       !$omp target teams distribute parallel do simd
       do icol = 1,ncol
         itropo_lower(icol,2) = nlay
-#ifdef _CRAYFTN
+#if defined(_CRAYFTN) || defined(__NVCOMPILER)
         itropo_upper(icol,1) = 1
         call minmaxloc(icol, tropo, play, itropo_lower(icol,1), itropo_upper(icol,2))
 #else
@@ -249,7 +249,7 @@ contains
       !$omp target teams distribute parallel do simd
       do icol = 1,ncol
         itropo_lower(icol,1) = 1
-#ifdef _CRAYFTN
+#if defined(_CRAYFTN) || defined(__NVCOMPILER)
         itropo_upper(icol,2) = nlay
         call minmaxloc(icol, tropo, play, itropo_lower(icol,2), itropo_upper(icol,1))
 #else


### PR DESCRIPTION
NVidia's Fortran OpenMP compiler has the same issue as Cray's Fortran OpenMP compiler. The runtime library does not support the `minloc` and `maxloc` Fortran intrinsic functions in an OpenMP target region. Hence, we use the in-house `minmaxloc` function instead. We activate the appropriate code segment by using the pre-defined compiler macro.

@alexeedm Could you request from NVidia compiler's team to support these functions in the OpenMP target region?