### PR TITLE
Minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Relative to commit `69d36c9` to `master` on Apr 20, 2020, the required arguments
 2. Set environment variables `RRTMGP_ROOT` to the top-level RTE+RRTMGP directory and `RTE_KERNELS` to `openacc` if you want the OpenACC/OpenMP kernels rather than the default.
 3. `make libs` in the top-level directory will make the RTE and RRTMGP libraries.
 4. The examples and testing codes use netCDF. Set the variables `NCHOME` and `NFHOME` to the roots of the C and Fortran netCDF installations, then `make tests` to build and run these. (A few files need to be downloaded for `examples/rfmaip-clear-sky`. The default is to download these with `wget` but a Python script is also available.)
-5. Evaluating the results of the tests requires `Python` with the `xarray` package and its depdencies installed. Comparisons can be made with `make check` in the top level directory.
+5. Evaluating the results of the tests requires `Python` with the `xarray` package and its dependencies installed. Comparisons can be made with `make check` in the top level directory.
 6. `make` invoked without a target in the top level attempts all three steps.
 
 ## Examples

--- a/extensions/cloud_optics/mo_cloud_optics.F90
+++ b/extensions/cloud_optics/mo_cloud_optics.F90
@@ -374,10 +374,10 @@ contains
                         optical_props) result(error_msg)
     class(ty_cloud_optics), &
               intent(in   ) :: this
-    real(wp), intent(in   ) :: clwp  (:,:), &   ! cloud ice water path    (g/m2)
-                               ciwp  (:,:), &   ! cloud liquid water path (g/m2)
-                               reliq (:,:), &   ! cloud ice particle effective size (microns)
-                               reice (:,:)      ! cloud liquid particle effective radius (microns)
+    real(wp), intent(in   ) :: clwp  (:,:), &   ! cloud liquid water path (g/m2)
+                               ciwp  (:,:), &   ! cloud ice water path    (g/m2)
+                               reliq (:,:), &   ! cloud liquid particle effective size (microns)
+                               reice (:,:)      ! cloud ice particle effective radius  (microns)
     class(ty_optical_props_arry), &
               intent(inout) :: optical_props
                                                ! Dimensions: (ncol,nlay,nbnd)

--- a/extensions/cloud_optics/mo_cloud_optics.F90
+++ b/extensions/cloud_optics/mo_cloud_optics.F90
@@ -643,7 +643,7 @@ contains
     integer  :: icol, ilay, ibnd
     integer  :: index
     real(wp) :: fint
-    real(wp) :: t, ts, tsg  ! tau, tau*ssa, tau*ssa*g
+    real(wp) :: t, ts  ! tau, tau*ssa, tau*ssa*g
     ! ---------------------------
     !$acc parallel loop gang vector default(present) collapse(3)
     !$omp target teams distribute parallel do simd collapse(3)
@@ -697,7 +697,7 @@ contains
                                     intent(in) :: coeffs_asy
     real(wp), dimension(ncol,nlay,nbnd)        :: tau, taussa, taussag
     ! ---------------------------
-    integer  :: icol, ilay, ibnd, irad, count
+    integer  :: icol, ilay, ibnd, irad
     real(wp) :: t, ts
 
     !$acc parallel loop gang vector default(present) collapse(3)

--- a/rte/kernels/mo_rte_solver_kernels.F90
+++ b/rte/kernels/mo_rte_solver_kernels.F90
@@ -871,8 +871,10 @@ contains
         source_dn(i,lay_index) =    Tdir * dir_flux_inc(i)
         dir_flux_trans(i)      = Tnoscat * dir_flux_inc(i)
       end do
+      if (j==nlay) then
+        source_sfc(:) = dir_flux_trans(:)*sfc_albedo(:)
+      endif
     end do
-    source_sfc(:) = dir_flux_trans(:)*sfc_albedo(:)
 
   end subroutine sw_dif_and_source
 ! ---------------------------------------------------------------

--- a/rte/kernels/mo_rte_solver_kernels.F90
+++ b/rte/kernels/mo_rte_solver_kernels.F90
@@ -871,10 +871,8 @@ contains
         source_dn(i,lay_index) =    Tdir * dir_flux_inc(i)
         dir_flux_trans(i)      = Tnoscat * dir_flux_inc(i)
       end do
-      if (j==nlay) then
-        source_sfc(:) = dir_flux_trans(:)*sfc_albedo(:)
-      endif
     end do
+    source_sfc(:) = dir_flux_trans(:)*sfc_albedo(:)
 
   end subroutine sw_dif_and_source
 ! ---------------------------------------------------------------


### PR DESCRIPTION
I just resolved three warnings that kept bothering me when compiling:

- unused variables `tsg` and `count` in `extensions/cloud_optics/mo_cloud_optics.F90` removed
- resolving a ` -Wmaybe-uninitialized warning` in the file `rte/kernels/mo_rte_solver_kernels.F90` by moving one statement inside a loop
- typo fixed in README.md