### PR TITLE
Remove invalid optional/intent attributes from DDT metadata

### DIFF
--- a/rte/mo_optical_props.meta
+++ b/rte/mo_optical_props.meta
@@ -45,21 +45,15 @@
   units = DDT
   dimensions = ()
   type = ty_optical_props_1scl
-  intent = in
-  optional = F
 [ty_optical_props_2str]
   standard_name = ty_optical_props_2str
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_2str
-  intent = in
-  optional = F
 [ty_optical_props_nstr]
   standard_name = ty_optical_props_nstr
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_nstr
-  intent = in
-  optional = F


### PR DESCRIPTION
## Description

The CCPP metadata for defining derived data types (DDTs) does not use the `intent` and `optional` attributes (they do not make sense when defining a DDT). This PR removes them.

## Associated PRs

https://github.com/NCAR/ccpp-framework/pull/408
https://github.com/earth-system-radiation/rte-rrtmgp/pull/143
https://github.com/NCAR/ccpp-physics/pull/766
https://github.com/NOAA-EMC/fv3atm/pull/416
https://github.com/ufs-community/ufs-weather-model/pull/892
https://github.com/ESCOMP/CCPPStandardNames/pull/23

For regression testing with the UFS, see https://github.com/ufs-community/ufs-weather-model/pull/892.