### PR TITLE
For develop: Simplify index logic in subroutine interpolate_3D in mo_gas_optics_kernels.F90

### DIFF
--- a/rrtmgp/kernels/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels/mo_gas_optics_kernels.F90
@@ -713,23 +713,23 @@ contains
     integer, dimension(2),       intent(in) :: jeta ! interpolation index for binary species parameter (eta)
     integer,                     intent(in) :: jtemp ! interpolation index for temperature
     integer,                     intent(in) :: jpress ! interpolation index for pressure
-    real(wp), dimension(gptE-gptS+1)        :: res ! the result
+    real(wp), dimension(gptS:gptE)          :: res ! the result
 
     ! Local variable
     integer :: igpt
     ! each code block is for a different reference temperature
-    do igpt = 1, gptE-gptS+1
+    do igpt = gptS, gptE
       res(igpt) =  &
         scaling(1) * &
-        ( fmajor(1,1,1) * k(jtemp, jeta(1)  , jpress-1, gptS+igpt-1 ) + &
-          fmajor(2,1,1) * k(jtemp, jeta(1)+1, jpress-1, gptS+igpt-1 ) + &
-          fmajor(1,2,1) * k(jtemp, jeta(1)  , jpress  , gptS+igpt-1 ) + &
-          fmajor(2,2,1) * k(jtemp, jeta(1)+1, jpress  , gptS+igpt-1 ) ) + &
+        ( fmajor(1,1,1) * k(jtemp, jeta(1)  , jpress-1, igpt) + &
+          fmajor(2,1,1) * k(jtemp, jeta(1)+1, jpress-1, igpt) + &
+          fmajor(1,2,1) * k(jtemp, jeta(1)  , jpress  , igpt) + &
+          fmajor(2,2,1) * k(jtemp, jeta(1)+1, jpress  , igpt) ) + &
         scaling(2) * &
-        ( fmajor(1,1,2) * k(jtemp+1, jeta(2)  , jpress-1, gptS+igpt-1) + &
-          fmajor(2,1,2) * k(jtemp+1, jeta(2)+1, jpress-1, gptS+igpt-1) + &
-          fmajor(1,2,2) * k(jtemp+1, jeta(2)  , jpress  , gptS+igpt-1) + &
-          fmajor(2,2,2) * k(jtemp+1, jeta(2)+1, jpress  , gptS+igpt-1) )
+        ( fmajor(1,1,2) * k(jtemp+1, jeta(2)  , jpress-1, igpt) + &
+          fmajor(2,1,2) * k(jtemp+1, jeta(2)+1, jpress-1, igpt) + &
+          fmajor(1,2,2) * k(jtemp+1, jeta(2)  , jpress  , igpt) + &
+          fmajor(2,2,2) * k(jtemp+1, jeta(2)+1, jpress  , igpt) )
     end do
   end function interpolate3D_byflav
 


### PR DESCRIPTION
This PR replaces https://github.com/earth-system-radiation/rte-rrtmgp/pull/151. It simplifies the logic in subroutine `interpolate_3D` in `mo_gas_optics_kernels.F90`. I have not run any tests with this except for compiling it, but from a visual inspection this should produce the same results.