### PR TITLE
Updated testing environments

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -113,7 +113,11 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-version: latest
-    - name: Install python packages
+        activate-environment: rte_rrtmgp_test
+        environment-file: environment.yml
+        python-version: 3.9
+        auto-activate-base: false
+  - name: Install python packages
       run: conda install --yes urllib3 netcdf4 xarray dask numpy scipy matplotlib seaborn colorcet
     ############################################################################
     - name: Cache RFMIP files

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -117,8 +117,6 @@ jobs:
         environment-file: environment.yml
         python-version: 3.9
         auto-activate-base: false
-  - name: Install python packages
-      run: conda install --yes urllib3 netcdf4 xarray dask numpy scipy matplotlib seaborn colorcet
     ############################################################################
     - name: Cache RFMIP files
       id: cache-rfmip-files

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,25 @@
+#
+# Python modules are needed to run tests and check results
+#    Also include gfortran and netCDF for development
+#
+name: rte_rrtmgp_dev
+dependencies:
+  - conda-forge::python=3.9
+  - conda-forge::urllib3
+  - conda-forge::netcdf4
+  - conda-forge::xarray
+  - conda-forge::dask
+  - conda-forge::numpy
+  - conda-forge::scipy
+  - conda-forge::matplotlib
+  - conda-forge::seaborn
+  - conda-forge::colorcet
+  - conda-forge::gfortran
+  - conda-forge::netcdf-fortran
+variables:
+  FC: gfortran
+  # Debugging flags below
+  FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DUSE_CBOOL"
+  # Shell environment variables can't be used within this YML files, so
+  # Users still need to set RRTMGP_ROOT,
+  #  NCHOME = CONDA_PREFIX, NFHOME = CONDA_PREFIX

--- a/environment.yml
+++ b/environment.yml
@@ -2,12 +2,15 @@
 # Python modules below are needed to run tests and check results
 #
 name: rte_rrtmgp_test
+
 dependencies:
-  - urllib3
-  - netcdf4
-  - xarray
-  - dask
-  - scipy
-  - matplotlib
-  - seaborn
-  - colorcet
+  - conda-forge::python=3.9
+  - conda-forge::urllib3
+  - conda-forge::netcdf4
+  - conda-forge::xarray
+  - conda-forge::dask
+  - conda-forge::numpy
+  - conda-forge::scipy
+  - conda-forge::matplotlib
+  - conda-forge::seaborn
+  - conda-forge::colorcet

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 #
-# Python modules below are needed to run tests and check results 
+# Python modules below are needed to run tests and check results
 #
-name: rte_rrtmgp
+name: rte_rrtmgp_test
 dependencies:
   - urllib3
   - netcdf4

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -70,7 +70,7 @@ check:
 	cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky && python ./compare-to-reference.py --fail=7.e-4
 
 multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc:
-	bash ./stage_files.sh
+	python stage_files.py
 
 clean:
 	-rm rrtmgp_rfmip_sw rrtmgp_rfmip_lw *.o *.mod *.optrpt *.nc

--- a/examples/rfmip-clear-sky/stage_files.py
+++ b/examples/rfmip-clear-sky/stage_files.py
@@ -1,39 +1,45 @@
 #! /usr/bin/env python
 #
-# This script downloads and creates files needed for the RFMIP off-line test cases
+# This script downloads and/or creates files needed for the RFMIP off-line test cases
 #
 import sys
-import os
 import subprocess
-import glob
+from pathlib import Path
 import urllib.request
-# This script invokes templ_scr_url, which uses Python modules time, uuid, argparse, netCDF4
 
 #
 # Download and/or create input files and output template files
 #
-rte_rrtmgp_dir  = os.path.join("..", "..")
-rfmip_dir       = os.path.join(rte_rrtmgp_dir, "examples", "rfmip-clear-sky")
+rte_rrtmgp_dir  = Path("..").joinpath("..")
+rfmip_dir       = rte_rrtmgp_dir.joinpath("examples", "rfmip-clear-sky")
 conds_file      = "multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc"
 conds_url       = "http://aims3.llnl.gov/thredds/fileServer/user_pub_work/input4MIPs/CMIP6/RFMIP/UColorado/UColorado-RFMIP-1-2/" + \
                   "atmos/fx/multiple/none/v20190401/" + conds_file
 #
 # The official RFMIP conditions are available from the ESFG, as above, but this fails from time to time, so
-#   we use the copy at NOAA PSL where the server is more robust
+#   we use the copy at Lamont-Doherty Earth Observatory, which we have to access via ftp(!)
 #
-conds_url       = "https://psl.noaa.gov/thredds/fileServer/Datasets/rte-rrtmgp/continuous-integration/" + conds_file
-templ_scr       = "generate-output-file-templates.py"
-templ_scr_url   = "https://raw.githubusercontent.com/RobertPincus/RFMIP-IRF-Scripts/master/" + templ_scr
+conds_url       = "ftp://ftp.ldeo.columbia.edu/pub/robertp/rte-rrtmgp/continuous-integration/" + conds_file
+output_files    = [f"r{wl}{dir}_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc"
+                   for wl in ['l', 's'] for dir in ['u', 'd']]
 #
 # Remove previous versions of files
 #
-for f in glob.glob("r??_Efx*.nc"): os.remove(f)
-for f in glob.glob("multiple_input4MIPs_radiation_RFMIP*.nc"): os.remove(f)
+for f in output_files: Path(f).unlink(missing_ok=True)
+Path(conds_file).unlink(missing_ok=True)
+
 #
 # Download the profiles for RFMIP; make the empty output files
 #
 print("Downloading RFMIP input files")
 urllib.request.urlretrieve(conds_url,     conds_file)
-print("Downloading scripts for generating output templates")
-urllib.request.urlretrieve(templ_scr_url, templ_scr)
-subprocess.run([sys.executable, templ_scr, "--source_id", "RTE-RRTMGP-181204"])
+
+generate_templates = False
+if generate_templates:
+    print("Downloading scripts for generating output templates")
+    urllib.request.urlretrieve(templ_scr_url, templ_scr)
+    subprocess.run([sys.executable, templ_scr, "--source_id", "RTE-RRTMGP-181204"])
+else:
+    print("Downloading output templates")
+    for f in output_files:
+        urllib.request.urlretrieve(conds_url.replace(conds_file, f), f)

--- a/examples/rfmip-clear-sky/stage_files.py
+++ b/examples/rfmip-clear-sky/stage_files.py
@@ -29,7 +29,7 @@ for f in output_files: Path(f).unlink(missing_ok=True)
 Path(conds_file).unlink(missing_ok=True)
 
 #
-# Download the profiles for RFMIP; make the empty output files
+# Download the profiles for RFMIP; download or make the empty output files
 #
 print("Downloading RFMIP input files")
 urllib.request.urlretrieve(conds_url,     conds_file)

--- a/tests/clear_sky_regression.F90
+++ b/tests/clear_sky_regression.F90
@@ -597,7 +597,8 @@ contains
     call write_broadband_field(input_file, flux_net, "lw_flux_net_alt_oa", "LW flux ne, fewer g-points, opt. angle")
     call stop_on_err(compute_heating_rate(flux_up, flux_dn, p_lev, heating_rate))
     call write_broadband_field(input_file, heating_rate,  &
-                                                     "lw_flux_hr_alt_oa",  "LW heating rate, fewer g-points, opt. angle", vert_dim_name = "layer")
+                                                     "lw_flux_hr_alt_oa",  "LW heating rate, fewer g-points, opt. angle", &
+                                                                                                         vert_dim_name = "layer")
     call k_dist_2%finalize()
   end subroutine lw_clear_sky_alt
   ! ----------------------------------------------------------------------------


### PR DESCRIPTION
Use `environment.yml` file to detail Python packages needed for testing and validation/verification, to be obtained from `conda`. The `environment-dev.yml` variant also includes gfortran compilers and the netCDF stack and can be used for development. 

Move to Python for downloading test files - should resolve #154 by eliminating `wget` 