### PR TITLE
Solar zenith angle can vary with height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 # Intel vectorization reports
 *.optrpt
 
+# Netcdf file during testing
+examples/*/*.nc
+examples/*/*/*.nc
+
 # Don't commit specific Makefile variants
 Makefile.libs
 Makefile.conf

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,8 @@
 examples/*/*.nc
 examples/*/*/*.nc
 
-# Don't commit specific Makefile variants
-Makefile.libs
-Makefile.conf
+# Jupyter notebooks
+.ipynb_checkpoints
 
 # Intel code coverage
 *.dyn

--- a/examples/all-sky/compare-to-reference.py
+++ b/examples/all-sky/compare-to-reference.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     # If a version of the file exists in the reference directory, no need to download (can be over-ridden)
     if (args.download_reference or not os.path.exists(ref_file)):
         os.makedirs(args.ref_dir, exist_ok=True)
-        urllib.request.urlretrieve("https://owncloud.gwdg.de/index.php/s/OjbNzRTlXUk0G5w/download", ref_file)
+        urllib.request.urlretrieve("ftp://ftp.ldeo.columbia.edu/pub/robertp/rte-rrtmgp/continuous-integration/rrtmgp-allsky.nc", ref_file)
     tst = xr.open_dataset(tst_file)
     ref = xr.open_dataset(ref_file)
 

--- a/extensions/mo_heating_rates.F90
+++ b/extensions/mo_heating_rates.F90
@@ -3,8 +3,10 @@
 ! Andre Wehe and Jennifer Delamere
 ! email:  rrtmgp@aer.com
 !
-! Copyright 2016-2017,  Atmospheric and Environmental Research and
-! Regents of the University of Colorado.  All right reserved.
+! Copyright 2016-  Atmospheric and Environmental Research,
+!    Regents of the University of Colorado,
+!    Trustees of Columbia University in the City of New York
+! All right reserved.
 !
 ! Use and duplication is permitted under the terms of the
 !    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
@@ -14,22 +16,26 @@
 module mo_heating_rates
   use mo_rte_kind,         only: wp, wl
   use mo_rte_config,       only: check_extents
-  use mo_rte_util_array,   only: extents_are
+  use mo_rte_util_array,   only: extents_are, any_vals_less_than
   use mo_rrtmgp_constants, only: cp_dry, grav ! Only needed for heating rate calculation
   implicit none
   private
+  interface compute_heating_rate
+      module procedure compute_heating_rate_general, compute_heating_rate_solar_varmu0
+  end interface compute_heating_rate
   public ::  compute_heating_rate
 contains
   ! Compute heating rate from fluxes
   ! heating rate H [K/sec] = 1/(rho cp) d f_net/d z
   ! Here use hydrostatic equation for density and heat capacity of dry air
-  function compute_heating_rate(flux_up, flux_dn, plev, heating_rate) result(error_msg)
+  ! --------------------------------------------------------------------------------------------------
+  function compute_heating_rate_general(flux_up, flux_dn, p_lev, heating_rate) result(error_msg)
     real(wp), dimension(:,:), intent(in ) :: flux_up, flux_dn, & !< fluxes at interfaces [W/m2]
-                                             plev                !< pressure at interfaces [Pa]
+                                             p_lev               !< pressure at interfaces [Pa]
     real(wp), dimension(:,:), intent(out) :: heating_rate        !< heating rate within layer [K/sec]
     character(len=128)                    :: error_msg
     ! ---------
-    integer :: ncol, nlay, ilay
+    integer :: ncol, nlay, ilay, icol
     ! ---------
     error_msg = ""
     ncol = size(flux_up, 1)
@@ -38,18 +44,75 @@ contains
     if(check_extents) then
       if(.not. extents_are(flux_dn,      ncol, nlay+1)) &
         error_msg = "heating_rate: flux_dn array inconsistently sized."
-      if(.not. extents_are(plev,         ncol, nlay+1)) &
-        error_msg = "heating_rate: plev array inconsistently sized."
+      if(.not. extents_are(p_lev,        ncol, nlay+1)) &
+        error_msg = "heating_rate: p_lev array inconsistently sized."
       if(.not. extents_are(heating_rate, ncol, nlay)) &
         error_msg = "heating_rate: heating_rate array inconsistently sized."
       if(error_msg /= "") return
     end if
 
     do ilay = 1, nlay
-      heating_rate(1:ncol,ilay) = (flux_up(1:ncol,ilay+1) - flux_up(1:ncol,ilay) - &
-                                   flux_dn(1:ncol,ilay+1) + flux_dn(1:ncol,ilay)) * &
-                                  grav / (cp_dry * (plev(1:ncol,ilay+1) - plev(1:ncol,ilay)))
+      do icol = 1, ncol
+        heating_rate(icol,ilay) = (flux_up(icol,ilay+1) - flux_up(icol,ilay) - &
+                                   flux_dn(icol,ilay+1) + flux_dn(icol,ilay)) * &
+                                  grav / (cp_dry * (p_lev(icol,ilay+1) - p_lev(icol,ilay)))
+      end do
     end do
+  end function compute_heating_rate_general
+  ! --------------------------------------------------------------------------------------------------
+  function compute_heating_rate_solar_varmu0(flux_up, flux_dn, flux_dir, p_lev, mu0, heating_rate) result(error_msg)
+    real(wp), dimension(:,:), intent(in ) :: flux_up, flux_dn, flux_dir, & !< fluxes at interfaces [W/m2]
+                                             p_lev                !< pressure at interfaces [Pa]
+    real(wp), dimension(:,:), intent(in ) :: mu0                 !< solar zenith angle at layer center
+    real(wp), dimension(:,:), intent(out) :: heating_rate        !< heating rate within layer [K/sec]
+    character(len=128)                    :: error_msg
+    ! ---------
+    integer :: ncol, nlay, icol, ilay
+    integer :: last_sunlight_layer(size(mu0, 1))
+    logical(wl) :: top_at_1
+    ! ---------
+    error_msg = ""
+    !
+    ! Start with the baseline calculation
+    !
+    error_msg = compute_heating_rate_general(flux_up, flux_dn, p_lev, heating_rate)
+    !
+    ! If there was an error, or if the sun is everywhere over the horizon, no need to proceed
+    !
+    if(error_msg /= "" .or. &
+       .not. any_vals_less_than(mu0, epsilon(mu0))) return
+    ncol = size(flux_up, 1)
+    nlay = size(flux_up, 2) - 1
 
-  end function compute_heating_rate
+    if(check_extents) then
+      if(.not. extents_are(flux_dir,     ncol, nlay+1)) &
+        error_msg = "heating_rate: flux_dir array inconsistently sized."
+      if(.not. extents_are(mu0,          ncol, nlay)) &
+        error_msg = "heating_rate: mu0 array inconsistently sized."
+    end if
+    !
+    ! In each column: find the layer in which mu0 transitions from non-zero to zero;
+    !   compute heating rates in this layer from the divergence of diffuse flux
+    !   (total - direct)
+    !
+    if (any_vals_less_than(mu0(:,nlay), epsilon(mu0))) then
+      ! Zero mu0 values in highest index implies top at 1
+      last_sunlight_layer = minloc(mu0, mask=mu0>0._wp, dim=2)+1
+    else
+      last_sunlight_layer = maxloc(mu0, mask=mu0>0._wp, dim=2)-1
+    end if
+    do icol = 1, ncol
+      ilay = last_sunlight_layer(icol)
+      if(ilay > 1 .and. last_sunlight_layer(icol) < nlay) then
+        !
+        ! Heating rate with diffuse (total minus dir) net (up minus down) flux
+        !
+        heating_rate(icol,ilay) = (flux_up (icol,ilay+1) - flux_up (icol,ilay) - &
+                                   flux_dn (icol,ilay+1) + flux_dn (icol,ilay) + &
+                                   flux_dir(icol,ilay+1) - flux_dir(icol,ilay)) * &
+                                  grav / (cp_dry * (p_lev(icol,ilay+1) - p_lev(icol,ilay)))
+      end if
+    end do
+  end function compute_heating_rate_solar_varmu0
+  ! --------------------------------------------------------------------------------------------------
 end module mo_heating_rates

--- a/extensions/mo_zenith_angle_spherical_correction.F90
+++ b/extensions/mo_zenith_angle_spherical_correction.F90
@@ -36,6 +36,7 @@ contains
     character(len=128)                      :: error_msg
 
     integer  :: ncol, nlay, icol, ilay
+    real(wp) :: sin_theta2
     ! ------------------------------------
     error_msg = ""
     ncol = size(alt,1)
@@ -67,10 +68,14 @@ contains
     !$omp map(to:ref_alt, ref_mu, alt) map(from:mu)
     do ilay=1, nlay
       do icol = 1, ncol
-        mu(icol, ilay) = sqrt( 1._wp - min(1._wp,            &
-                                       (1-ref_mu(icol)**2) * &
-                                       ((planet_radius + ref_alt(icol)) / &
-                                        (planet_radius + alt(icol,ilay)))**2 )  )
+        sin_theta2 = (1-ref_mu(icol)**2) * &
+                     ((planet_radius + ref_alt(icol)) / &
+                      (planet_radius + alt(icol,ilay)))**2 
+        if(sin_theta2 < 1._wp) then
+          mu(icol, ilay) = sqrt(1._wp - sin_theta2)
+        else
+          mu(icol, ilay) = 0._wp
+        end if
       end do
     end do
   end function zenith_angle_with_height

--- a/extensions/mo_zenith_angle_spherical_correction.F90
+++ b/extensions/mo_zenith_angle_spherical_correction.F90
@@ -1,0 +1,94 @@
+! This code is part of Radiative Transfer for Energetics (RTE)
+!
+! Contacts: Robert Pincus and Eli Mlawer
+! email:  rrtmgp@aer.com
+!
+! Copyright 2020-,  Atmospheric and Environmental Research,
+! Regents of the University of Colorado, Trustees of Columbia University.  All right reserved.
+!
+! Use and duplication is permitted under the terms of the
+!    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+! -------------------------------------------------------------------------------------------------
+!
+! Routines for solar zenith angle accounting for spherical geometry
+!
+! -------------------------------------------------------------------------------------------------
+
+module mo_zenith_angle_spherical_correction
+  use mo_rte_kind,       only: wp, wl
+  use mo_rte_config,     only: check_extents, check_values
+  use mo_rte_util_array, only: extents_are, any_vals_outside, any_vals_less_than
+  implicit none
+  private
+  public :: zenith_angle_with_height
+
+  real(wp), protected :: planet_radius = 6371.23_wp * 1.e3_wp ! Planetary radius [m]
+contains
+  ! -------------------------------------------------------------------------------------------------
+  !
+  ! Compute cosine of solar zenith angle (min 0) as a function of height given value at a specified height.
+  !
+  function zenith_angle_with_height(ref_alt, ref_mu, alt, mu) result(error_msg)
+    real(wp), dimension(:),   intent(in   ) :: ref_alt ! reference altitude at which solar zenith angle is provided [m]
+    real(wp), dimension(:),   intent(in   ) :: ref_mu  ! cosine of the solar zenith angle at reference altitude
+    real(wp), dimension(:,:), intent(in   ) :: alt    ! level altitude grid [m]
+    real(wp), dimension(:,:), intent(  out) :: mu
+    character(len=128)                      :: error_msg
+
+    integer  :: ncol, nlay, icol, ilay
+    ! ------------------------------------
+    error_msg = ""
+    ncol = size(alt,1)
+    nlay = size(alt,2)
+
+    if(check_extents) then
+      if(.not. extents_are(ref_alt, ncol)) &
+        error_msg = "zenith_angle_with_height: ref_alt, alt have different number of columns"
+      if(.not. extents_are(ref_mu, ncol)) &
+        error_msg = "zenith_angle_with_height: ref_mu, alt have different number of columns"
+      if(.not. extents_are(mu,    ncol, nlay)) &
+        error_msg = "zenith_angle_with_height: mu, alt have different number of columns"
+    end if
+    if(len_trim(error_msg) /= 0) return
+
+    if(check_extents) then
+      if(any_vals_less_than(ref_alt, -planet_radius)) &
+        error_msg = "zenith_angle_with_height: values of ref_mu must be in [-1, 1]"
+      if(any_vals_outside(ref_mu, -1._wp, 1._wp)) &
+        error_msg = "zenith_angle_with_height: values of ref_mu must be in [-1, 1]"
+      if(any_vals_less_than(alt, -planet_radius)) &
+        error_msg = "zenith_angle_with_height: values of alt are smaller than planetary radius"
+    end if
+    if(len_trim(error_msg) /= 0) return
+    ! ------------------------------------
+    !$acc                         parallel loop    collapse(2) &
+    !$acc copyin(ref_alt, ref_mu, alt) copyout(mu)
+    !$omp target teams distribute parallel do simd collapse(2) &
+    !$omp map(to:ref_alt, ref_mu, alt) map(from:mu)
+    do ilay=1, nlay
+      do icol = 1, ncol
+        mu(icol, ilay) = sqrt( 1._wp - min(1._wp,            &
+                                       (1-ref_mu(icol)**2) * &
+                                       ((planet_radius + ref_alt(icol)) / &
+                                        (planet_radius + alt(icol,ilay)))**2 )  )
+      end do
+    end do
+  end function zenith_angle_with_height
+  ! -------------------------------------------------------------------------------------------------
+  !
+  ! Set the planetary radius used for computing solar zenith angle
+  !
+  function set_planet_radius(radius) result (error_msg)
+    real(wp), intent(in) :: radius
+    character(len=128)   :: error_msg
+
+    error_msg = ""
+    if(radius .le. 0._wp) then
+      error_msg = "set_planet_radius: radius must be > 0"
+      return
+    end if
+
+    planet_radius = radius
+  end function set_planet_radius
+  ! -------------------------------------------------------------------------------------------------
+end module mo_zenith_angle_spherical_correction

--- a/extensions/mo_zenith_angle_spherical_correction.F90
+++ b/extensions/mo_zenith_angle_spherical_correction.F90
@@ -54,11 +54,11 @@ contains
 
     if(check_extents) then
       if(any_vals_less_than(ref_alt, -planet_radius)) &
-        error_msg = "zenith_angle_with_height: values of ref_mu must be in [-1, 1]"
+        error_msg = "zenith_angle_with_height: values of ref_alt must be larger than -the planetary radius"
       if(any_vals_outside(ref_mu, -1._wp, 1._wp)) &
         error_msg = "zenith_angle_with_height: values of ref_mu must be in [-1, 1]"
       if(any_vals_less_than(alt, -planet_radius)) &
-        error_msg = "zenith_angle_with_height: values of alt are smaller than planetary radius"
+        error_msg = "zenith_angle_with_height: values of alt must be larger than -the planetary radius"
     end if
     if(len_trim(error_msg) /= 0) return
     ! ------------------------------------
@@ -70,7 +70,7 @@ contains
       do icol = 1, ncol
         sin_theta2 = (1-ref_mu(icol)**2) * &
                      ((planet_radius + ref_alt(icol)) / &
-                      (planet_radius + alt(icol,ilay)))**2 
+                      (planet_radius + alt(icol,ilay)))**2
         if(sin_theta2 < 1._wp) then
           mu(icol, ilay) = sqrt(1._wp - sin_theta2)
         else

--- a/rte/kernels-openacc/mo_rte_solver_kernels.F90
+++ b/rte/kernels-openacc/mo_rte_solver_kernels.F90
@@ -1064,8 +1064,9 @@ contains
                                 flux_dn_dir) bind (C, name="rte_sw_source_dir")
     integer,                               intent(in   ) :: ncol, nlay, ngpt
     logical(wl),                           intent(in   ) :: top_at_1
+    real(wp), dimension(ncol,nlay       ), intent(in   ) :: mu0
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_albedo          ! surface albedo for direct radiation
-    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: tau, w0, g, mu0
+    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: tau, w0, g
     real(wp), dimension(ncol,nlay,  ngpt), target, &
                                            intent(  out) :: Rdif, Tdif, source_dn, source_up
     real(wp), dimension(ncol,       ngpt), intent(  out) :: source_sfc ! Source function for upward radation at surface
@@ -1130,10 +1131,10 @@ contains
           RT_term = 1._wp / (k      * (1._wp + exp_minus2ktau)  + &
                              gamma1 * (1._wp - exp_minus2ktau) )
           ! Equation 25
-          Rdif(i,lay_index) = RT_term * gamma2 * (1._wp - exp_minus2ktau)
+          Rdif(icol,lay_index,igpt) = RT_term * gamma2 * (1._wp - exp_minus2ktau)
 
           ! Equation 26
-          Tdif(i,lay_index) = RT_term * 2._wp * k * exp_minusktau
+          Tdif(icol,lay_index,igpt) = RT_term * 2._wp * k * exp_minusktau
 
           !
           ! On a round earth, where mu0 can increase with depth in the atmosphere,
@@ -1176,13 +1177,13 @@ contains
                   ((1._wp + k_mu) * (alpha1 + k_gamma4)                  * Tnoscat - &
                    (1._wp - k_mu) * (alpha1 - k_gamma4) * exp_minus2ktau * Tnoscat - &
                    2.0_wp * (k_gamma4 + alpha1 * k_mu)  * exp_minusktau)
-            source_up(i,lay_index) =    Rdir * dir_flux_inc(i)
-            source_dn(i,lay_index) =    Tdir * dir_flux_inc(i)
-            dir_flux_trans(i)      = Tnoscat * dir_flux_inc(i)
+            source_up  (icol,lay_index,  igpt) =    Rdir * inc_flux
+            source_dn  (icol,lay_index,  igpt) =    Tdir * inc_flux
+            flux_dn_dir(icol,trans_index,igpt) = Tnoscat * inc_flux
           else
-            source_up(i,lay_index) = 0._wp
-            source_dn(i,lay_index) = 0._wp
-            dir_flux_trans(i)      = 0._wp
+            source_up  (icol,lay_index,  igpt) = 0._wp
+            source_dn  (icol,lay_index,  igpt) = 0._wp
+            flux_dn_dir(icol,trans_index,igpt) = 0._wp
           end if
         end do
         source_sfc(icol,igpt) = flux_dn_dir(icol,trans_index,igpt)*sfc_albedo(icol,igpt)

--- a/rte/kernels-openacc/mo_rte_solver_kernels.F90
+++ b/rte/kernels-openacc/mo_rte_solver_kernels.F90
@@ -594,7 +594,7 @@ contains
     logical(wl),                           intent(in ) :: do_broadband ! Provide broadband-integrated, not spectrally-resolved, fluxes?
     real(wp), dimension(ncol,nlay+1     ), intent(out) :: broadband_up, broadband_dn, broadband_dir
     ! -------------------------------------------
-    integer  :: icol, ilay, igpt, top_level
+    integer  :: icol, ilay, igpt, top_level, top_layer
     real(wp) :: bb_flux_s, bb_dir_s
     real(wp), dimension(ncol,nlay,ngpt) :: Rdif, Tdif
     real(wp), dimension(ncol,nlay,ngpt) :: source_up, source_dn
@@ -610,8 +610,13 @@ contains
       gpt_flux_dn  => flux_dn
       gpt_flux_dir => flux_dir
     end if
-    top_level = nlay+1
-    if(top_at_1) top_level = 1
+    if(top_at_1) then
+      top_level = 1
+      top_layer = 1
+    else
+      top_level = nlay+1
+      top_layer = nlay
+    end if
     !
     ! Boundary conditions direct beam...
     !
@@ -627,7 +632,7 @@ contains
     !$omp target teams distribute parallel do simd collapse(2)
     do igpt = 1, ngpt
       do icol = 1, ncol
-        gpt_flux_dir(icol, top_level, igpt)  = inc_flux_dir(icol,igpt) * mu0(icol, top_level)
+        gpt_flux_dir(icol, top_level, igpt)  = inc_flux_dir(icol,igpt) * mu0(icol, top_layer)
       end do
     end do
 

--- a/rte/kernels/mo_rte_solver_kernels.F90
+++ b/rte/kernels/mo_rte_solver_kernels.F90
@@ -524,7 +524,7 @@ contains
     logical(wl),                           intent(in   ) :: do_broadband ! Provide broadband-integrated, not spectrally-resolved, fluxes?
     real(wp), dimension(ncol,nlay+1     ), intent(  out) :: broadband_up, broadband_dn, broadband_dir
     ! -------------------------------------------           ! Broadband integrated fluxes
-    integer :: igpt, top_level
+    integer :: igpt, top_level, top_layer
     real(wp), dimension(ncol,nlay  )  :: Rdif, Tdif
     real(wp), dimension(ncol,nlay  )  :: source_up, source_dn
     real(wp), dimension(ncol       )  :: source_srf
@@ -535,8 +535,13 @@ contains
     ! gpt_fluxes point to calculations for the current g-point
     real(wp), dimension(:,:), pointer :: gpt_flux_up, gpt_flux_dn, gpt_flux_dir
     ! ------------------------------------
-    top_level = nlay+1
-    if(top_at_1) top_level = 1
+    if(top_at_1) then
+      top_level = 1
+      top_layer = 1
+    else
+      top_level  = nlay+1
+      top_layer  = nlay
+    end if
     !
     ! Integrated fluxes need zeroing
     !
@@ -559,7 +564,7 @@ contains
       !
       ! Boundary conditions direct beam...
       !
-      gpt_flux_dir(:,top_level) = inc_flux_dir(:,igpt) * mu0(:,top_level)
+      gpt_flux_dir(:,top_level) = inc_flux_dir(:,igpt) * mu0(:,top_layer)
       !
       ! ... and diffuse field, using 0 if no BC is provided
       !

--- a/rte/mo_rte_sw.F90
+++ b/rte/mo_rte_sw.F90
@@ -181,8 +181,8 @@ contains
     ! Values of input arrays
     !
     if(check_values) then
-      if(any_vals_outside(mu0, 0._wp, 1._wp)) &
-        error_msg = "rte_sw: one or more mu0 <= 0 or > 1"
+      if(any_vals_outside(mu0, -1._wp, 1._wp)) &
+        error_msg = "rte_sw: one or more mu0 < -1 or > 1"
       if(any_vals_less_than(inc_flux, 0._wp)) &
         error_msg = "rte_sw: one or more inc_flux < 0"
       if(any_vals_outside(sfc_alb_dir,  0._wp, 1._wp)) &

--- a/rte/mo_rte_sw.F90
+++ b/rte/mo_rte_sw.F90
@@ -76,16 +76,18 @@ contains
       !! If empty, calculation was successful
     ! --------------------------------
     real(wp), dimension(size(mu0), atmos%get_nlay()) :: mu0_bylay
-    integer :: i, j
+    integer :: i, j, ncol, nlay
 
+    ncol = size(mu0)
+    nlay = atmos%get_nlay()
     ! Solar zenith angle cosine is constant with height
     !$acc        data copyin(mu0)    create(mu0_bylay)
     !$omp target data map(to:mu0) map(alloc:mu0_bylay)
 
     !$acc                         parallel loop    collapse(2)
     !$omp target teams distribute parallel do simd collapse(2)
-    do j = 1, atmos%get_nlay()
-      do i = 1, size(mu0)
+    do j = 1, nlay
+      do i = 1, ncol
         mu0_bylay(i,j) = mu0(i)
       end do
     end do

--- a/rte/mo_rte_sw.F90
+++ b/rte/mo_rte_sw.F90
@@ -44,20 +44,70 @@ module mo_rte_sw
   implicit none
   private
 
+  interface rte_sw
+    module procedure rte_sw_mu0_bycol, rte_sw_mu0_full
+  end interface rte_sw
   public :: rte_sw
 
 contains
-  ! --------------------------------------------------
-  function rte_sw(atmos, top_at_1,                 &
-                  mu0, inc_flux,                   &
-                  sfc_alb_dir, sfc_alb_dif,        &
+  ! -------------------------------------------------------------------------------------------------
+  function rte_sw_mu0_bycol(atmos, top_at_1, &
+                  mu0, inc_flux,             &
+                  sfc_alb_dir, sfc_alb_dif,  &
                   fluxes, inc_flux_dif) result(error_msg)
     class(ty_optical_props_arry), intent(in   ) :: atmos
       !! Optical properties provided as arrays
     logical,                      intent(in   ) :: top_at_1
       !! Is the top of the domain at index 1? (if not, ordering is bottom-to-top)
     real(wp), dimension(:),       intent(in   ) :: mu0
-      !! cosine of solar zenith angle (ncol)
+      !! cosine of solar zenith angle (ncol) - will be assumed constant with height
+    real(wp), dimension(:,:),     intent(in   ) :: inc_flux
+      !! incident flux at top of domain [W/m2] (ncol, ngpt)
+    real(wp), dimension(:,:),     intent(in   ) :: sfc_alb_dir
+      !! surface albedo for direct and
+    real(wp), dimension(:,:),     intent(in   ) :: sfc_alb_dif
+      !! diffuse radiation (nband, ncol)
+    class(ty_fluxes),             intent(inout) :: fluxes
+      !! Class describing output calculations
+    real(wp), dimension(:,:), optional, target, &
+                                  intent(in   ) :: inc_flux_dif
+      !! incident diffuse flux at top of domain [W/m2] (ncol, ngpt)
+    character(len=128)                          :: error_msg
+      !! If empty, calculation was successful
+    ! --------------------------------
+    real(wp), dimension(size(mu0), atmos%get_nlay()) :: mu0_bylay
+    integer :: i, j
+
+    ! Solar zenith angle cosine is constant with height
+    !$acc        data copyin(mu0)    create(mu0_bylay)
+    !$omp target data map(to:mu0) map(alloc:mu0_bylay)
+
+    !$acc                         parallel loop    collapse(2)
+    !$omp target teams distribute parallel do simd collapse(2)
+    do j = 1, atmos%get_nlay()
+      do i = 1, size(mu0)
+        mu0_bylay(i,j) = mu0(i)
+      end do
+    end do
+
+    error_msg = rte_sw_mu0_full(atmos, top_at_1, &
+                    mu0_bylay, inc_flux,         &
+                    sfc_alb_dir, sfc_alb_dif,    &
+                    fluxes, inc_flux_dif)
+    !$acc end data
+    !$omp end target data
+  end function rte_sw_mu0_bycol
+  ! -------------------------------------------------------------------------------------------------
+  function rte_sw_mu0_full(atmos, top_at_1, &
+                  mu0, inc_flux,            &
+                  sfc_alb_dir, sfc_alb_dif, &
+                  fluxes, inc_flux_dif) result(error_msg)
+    class(ty_optical_props_arry), intent(in   ) :: atmos
+      !! Optical properties provided as arrays
+    logical,                      intent(in   ) :: top_at_1
+      !! Is the top of the domain at index 1? (if not, ordering is bottom-to-top)
+    real(wp), dimension(:,:),     intent(in   ) :: mu0
+      !! cosine of solar zenith angle (ncol, nlay)
     real(wp), dimension(:,:),     intent(in   ) :: inc_flux
       !! incident flux at top of domain [W/m2] (ncol, ngpt)
     real(wp), dimension(:,:),     intent(in   ) :: sfc_alb_dir
@@ -112,7 +162,7 @@ contains
     !$acc        data copyin(inc_flux_dif) if (has_dif_bc)
     !$omp target data map(to:inc_flux_dif) if (has_dif_bc)
     if(check_extents) then
-      if(.not. extents_are(mu0, ncol)) &
+      if(.not. extents_are(mu0, ncol, nlay)) &
         error_msg = "rte_sw: mu0 inconsistently sized"
       if(.not. extents_are(inc_flux, ncol, ngpt)) &
         error_msg = "rte_sw: inc_flux inconsistently sized"
@@ -328,7 +378,7 @@ contains
       deallocate(inc_flux_diffuse)
     end if
 
-  end function rte_sw
+  end function rte_sw_mu0_full
   !--------------------------------------------------------------------------------------------------------------------
   !
   ! Expand from band to g-point dimension, transpose dimensions (nband, ncol) -> (ncol,ngpt)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -65,7 +65,7 @@ tests:
 	cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ./test_atmospheres.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g128-210809.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g112-210809.nc
-	./test_zenith_angle_spherical_correction 
+	$(RUN_CMD) ./test_zenith_angle_spherical_correction 
 
 check:
 	python verification.py

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -65,7 +65,6 @@ tests:
 	cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ./test_atmospheres.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g128-210809.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g112-210809.nc
-	$(RUN_CMD) ./test_zenith_angle_spherical_correction
 
 check:
 	python verification.py

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,10 +43,13 @@ LIB_DEPS = $(RRTMGP_BUILD)/librte.a $(RRTMGP_BUILD)/librrtmgp.a
 #
 # Targets
 #
-all: clear_sky_regression
+all: clear_sky_regression test_zenith_angle_spherical_correction
 
 clear_sky_regression:   $(ADDITIONS) $(LIB_DEPS) clear_sky_regression.o
 clear_sky_regression.o: $(ADDITIONS) $(LIB_DEPS) clear_sky_regression.F90
+
+test_zenith_angle_spherical_correction:   mo_zenith_angle_spherical_correction.o $(LIB_DEPS) test_zenith_angle_spherical_correction.o
+test_zenith_angle_spherical_correction.o: mo_zenith_angle_spherical_correction.o $(LIB_DEPS) test_zenith_angle_spherical_correction.F90
 
 mo_testing_io.o:        $(LIB_DEPS) mo_simple_netcdf.o mo_testing_io.F90
 
@@ -62,6 +65,7 @@ tests:
 	cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ./test_atmospheres.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g128-210809.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g112-210809.nc
+	./test_zenith_angle_spherical_correction 
 
 check:
 	python verification.py

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -48,8 +48,8 @@ all: clear_sky_regression test_zenith_angle_spherical_correction
 clear_sky_regression:   $(ADDITIONS) $(LIB_DEPS) clear_sky_regression.o
 clear_sky_regression.o: $(ADDITIONS) $(LIB_DEPS) clear_sky_regression.F90
 
-test_zenith_angle_spherical_correction:   mo_zenith_angle_spherical_correction.o $(LIB_DEPS) test_zenith_angle_spherical_correction.o
-test_zenith_angle_spherical_correction.o: mo_zenith_angle_spherical_correction.o $(LIB_DEPS) test_zenith_angle_spherical_correction.F90
+test_zenith_angle_spherical_correction:   mo_zenith_angle_spherical_correction.o mo_rcemip_profiles.o $(ADDITIONS) $(LIB_DEPS) test_zenith_angle_spherical_correction.o
+test_zenith_angle_spherical_correction.o: mo_zenith_angle_spherical_correction.o mo_rcemip_profiles.o $(ADDITIONS) $(LIB_DEPS) test_zenith_angle_spherical_correction.F90
 
 mo_testing_io.o:        $(LIB_DEPS) mo_simple_netcdf.o mo_testing_io.F90
 
@@ -65,7 +65,7 @@ tests:
 	cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ./test_atmospheres.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g128-210809.nc
 	$(RUN_CMD) ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g112-210809.nc
-	$(RUN_CMD) ./test_zenith_angle_spherical_correction 
+	$(RUN_CMD) ./test_zenith_angle_spherical_correction
 
 check:
 	python verification.py

--- a/tests/Readme.md
+++ b/tests/Readme.md
@@ -1,0 +1,23 @@
+# Tests
+
+This directory contains testing codes used in development.
+
+## Verification and validation
+
+The Makefile target `clear_sky_regression` is used for verification, meaning
+ensuring the package produces results as expected (e.g. that the
+rescaling approximation used for LW scattering reduces to the no-scattering
+solution in the absence of clouds), and for validation, meaning 
+comparisons among different approaches (e.g. different numbers of streams).
+
+## Feature testing
+
+The Makefile target `test_zenith_angle_spherical_correction` tests features related
+to computing solar radiation in spherical geometry, including codes for computing
+solar zenith angle as a function of height (`extensions/mo_zenith_angle_spherical_correction.F90`)
+and fluxes computed with height-dependent zenith angle.
+
+Module `mo_rcemip_profiles.F90` provides profiles of temperature, height, and gas
+concentrations given an arbitrary set of pressure levels, based on the
+[protocol](https://doi.org/10.5194/gmd-11-793-2018) for the
+[Radiative-Convective Equilibrium MIP](https://myweb.fsu.edu/awing/rcemip.html).

--- a/tests/clear_sky_regression.F90
+++ b/tests/clear_sky_regression.F90
@@ -147,17 +147,7 @@ program rte_clear_sky_regression
   !
   nbnd = k_dist%get_nband()
   ngpt = k_dist%get_ngpt()
-  !
-  ! RRTMGP won't run with pressure less than its minimum. The top level in the RFMIP file
-  !   is set to 10^-3 Pa. Here we pretend the layer is just a bit less deep.
-  !
   top_at_1 = p_lay(1, 1) < p_lay(1, nlay)
-  if(top_at_1) then
-    p_lev(:,1) = k_dist%get_press_min() + epsilon(k_dist%get_press_min())
-  else
-    p_lev(:,nlay+1) &
-                 = k_dist%get_press_min() + epsilon(k_dist%get_press_min())
-  end if
   ! ----------------------------------------------------------------------------
   !
   !  Boundary conditions

--- a/tests/mo_rcemip_profiles.F90
+++ b/tests/mo_rcemip_profiles.F90
@@ -1,0 +1,84 @@
+module mo_rcemip_profiles
+  use mo_rte_kind,           only: wp, wl
+  use mo_gas_concentrations, only: ty_gas_concs
+  implicit none
+  private
+  public :: make_rcemip_profile_given_p
+!
+! Provides temperature, pressure, height, and gas concentrations following
+!    the protocol for the Radiative-Convective Equilibrium MIP
+!    (Wing et al. 2018, https://doi.org/10.5194/gmd-11-793-2018.)
+!
+  real(wp), parameter :: molar_mass_h2o = 18.015_wp, molar_mass_air = 28.9644_wp
+!
+! RCEMIP parameters
+!
+  real(wp), parameter :: g  = 9.79764, & ! m/s^2
+                         Rd  = 287.04, & !/kgK
+                         p0  = 101480, & !Pa surface pressure
+                         qt  = 1.E-14, & !g/g specific humidity at tropopause. Prior to 02Sept2020, errorenously specified as 10^(-11)
+                         zq1 = 4000, & ! m
+                         zq2 = 7500, & ! m
+                         zt  = 15000, & ! m, tropopause height
+                         gamma = 0.0067 ! K/m lapse rate
+  real(wp), parameter :: chi_co2 = 348.e-6, chi_ch4 = 1650.e-9, chi_n2o = 306.e-9
+
+  real(wp), parameter :: SST = 295, q0 = 0.01200 ! specific humudity/mass mixing ratio
+  real(wp), parameter :: g1 = 3.6478, g2 = 0.83209, g3 = 11.3515 ! ozone profile parameters
+contains
+  ! ------------------------------------------------------------------------------
+  elemental subroutine zt_given_p(p, z, temp, q, o3)
+    real(wp), intent(in ) :: p
+    real(wp), intent(out) :: z
+    real(wp), optional, &
+              intent(out) :: temp, q, o3 ! K, specific humidity/mmr, vmr
+
+    real(wp) :: T0, Tv0, Tvt, pt
+    real(wp) :: Tv, q_local
+
+    T0 = SST ! surface air temperature is SST
+
+    ! Virtual Temperature at surface and tropopause
+    Tv0 = T0*(1 + 0.608*q0) ! virtual temperature at surface
+    Tvt = Tv0 - gamma*zt    ! virtual temperature at tropopause
+
+    ! Pressure at tropopause (p(zt))
+    pt = p0*(Tvt/Tv0)**(g/(Rd*gamma))
+
+    ! Height, specific humidity, virtual temperature
+    if (z .le. zt) then
+      z = (Tv0/gamma)*(1-(p/p0)**((Rd*gamma)/g))
+      q_local = q0*exp(-z/zq1)*exp(-(z/zq2)**2)
+      Tv = Tv0 - gamma*z
+    else
+      z  = zt + (Rd*Tvt/g)*log(pt/p)
+      q_local  = qt
+      Tv = Tvt
+    end if
+
+    ! Temperature
+    if(present(temp)) temp = Tv/(1 + 0.608*q_local)
+    ! specific humidity/mass mixing ratio -> molar mixing ratio
+    if(present(q   )) q  = q_local * molar_mass_air/molar_mass_h2o
+    ! Eq 1, converting from Pa to hPa and from ppmv to molar mixing ratio
+    if(present(o3  )) o3 = g1 * (p/100._wp)**g2 * exp(-p/(100._wp * g3)) * 1.e-6
+  end subroutine zt_given_p
+  ! ------------------------------------------------------------------------------
+  function make_rcemip_profile_given_p(p, temp, z, gas_concs) result(error_msg)
+    real(wp), dimension(:), intent(in   ) :: p
+    real(wp), dimension(:), intent(  out) :: temp, z
+    type(ty_gas_concs),     optional, &
+                            intent(inout) :: gas_concs
+    character(len=128)                    :: error_msg
+
+
+    if(present(gas_concs)) then
+      call gas_concs%reset()
+      error_msg = gas_concs%set_vmr("co2", chi_co2)
+      error_msg = gas_concs%set_vmr("ch4", chi_ch4)
+      error_msg = gas_concs%set_vmr("n2o", chi_n2o)
+      ! Don't forget water vapor, ozone
+    end if
+  end function make_rcemip_profile_given_p
+  ! ------------------------------------------------------------------------------
+end module mo_rcemip_profiles

--- a/tests/mo_rcemip_profiles.F90
+++ b/tests/mo_rcemip_profiles.F90
@@ -1,52 +1,68 @@
-module mo_rcemip_profiles
-  use mo_rte_kind,           only: wp, wl
-  use mo_gas_concentrations, only: ty_gas_concs
-  implicit none
-  private
-  public :: make_rcemip_profile_given_p
+! This code is part of Radiative Transfer for Energetics (RTE)
+!
+! Contacts: Robert Pincus and Eli Mlawer
+! email:  rrtmgp@aer.com
+!
+! Copyright 2022-  Atmospheric and Environmental Research and
+! Trustees of Columbia University in New York.  All right reserved.
+!
+! Use and duplication is permitted under the terms of the
+!    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+! ------------------------------------------------------------------------------
 !
 ! Provides temperature, pressure, height, and gas concentrations following
 !    the protocol for the Radiative-Convective Equilibrium MIP
 !    (Wing et al. 2018, https://doi.org/10.5194/gmd-11-793-2018.)
 !
+! ------------------------------------------------------------------------------
+module mo_rcemip_profiles
+  use mo_rte_kind,           only: wp, wl
+  use mo_rte_util_array,     only: extents_are
+  use mo_gas_concentrations, only: ty_gas_concs
+  implicit none
+  private
+  public :: make_rcemip_profile_given_p, make_rcemip_profiles
+
+  character(len=3), dimension(6), parameter :: rcemip_gases = ["h2o", "co2", "o3 ", "ch4", "n2o", "o2 "]
   real(wp), parameter :: molar_mass_h2o = 18.015_wp, molar_mass_air = 28.9644_wp
-!
-! RCEMIP parameters
-!
+  !
+  ! RCEMIP parameters
+  !
   real(wp), parameter :: g  = 9.79764, & ! m/s^2
                          Rd  = 287.04, & !/kgK
                          p0  = 101480, & !Pa surface pressure
                          qt  = 1.E-14, & !g/g specific humidity at tropopause. Prior to 02Sept2020, errorenously specified as 10^(-11)
-                         zq1 = 4000, & ! m
-                         zq2 = 7500, & ! m
-                         zt  = 15000, & ! m, tropopause height
-                         gamma = 0.0067 ! K/m lapse rate
+                         zq1 = 4000,   & ! m
+                         zq2 = 7500,   & ! m
+                         zt  = 15000,  & ! m, tropopause height
+                         gamma = 0.0067  ! K/m lapse rate
   real(wp), parameter :: chi_co2 = 348.e-6, chi_ch4 = 1650.e-9, chi_n2o = 306.e-9
 
   real(wp), parameter :: SST = 295, q0 = 0.01200 ! specific humudity/mass mixing ratio
   real(wp), parameter :: g1 = 3.6478, g2 = 0.83209, g3 = 11.3515 ! ozone profile parameters
+  ! For fixed SST
+  real(wp), parameter :: T0 = SST                ! surface air temperature is SST
+  real(wp), parameter :: Tv0 = T0*(1 + 0.608*q0) ! virtual temperature at surface
+  real(wp), parameter :: Tvt = Tv0 - gamma*zt    ! virtual temperature at tropopause
+  ! Pressure at tropopause (p(zt))
+  real(wp), parameter :: pt = p0*(Tvt/Tv0)**(g/(Rd*gamma))
+
 contains
   ! ------------------------------------------------------------------------------
+  !
+  ! Given pressure in Pa, provide values of temperature in K, height in m,
+  !   and (optionally) water vapor and ozone volume mixing ratios
+  !
   elemental subroutine zt_given_p(p, z, temp, q, o3)
     real(wp), intent(in ) :: p
     real(wp), intent(out) :: z
     real(wp), optional, &
               intent(out) :: temp, q, o3 ! K, specific humidity/mmr, vmr
-
-    real(wp) :: T0, Tv0, Tvt, pt
+    ! ----------------------------------
     real(wp) :: Tv, q_local
-
-    T0 = SST ! surface air temperature is SST
-
-    ! Virtual Temperature at surface and tropopause
-    Tv0 = T0*(1 + 0.608*q0) ! virtual temperature at surface
-    Tvt = Tv0 - gamma*zt    ! virtual temperature at tropopause
-
-    ! Pressure at tropopause (p(zt))
-    pt = p0*(Tvt/Tv0)**(g/(Rd*gamma))
-
+    ! ----------------------------------
     ! Height, specific humidity, virtual temperature
-    if (z .le. zt) then
+    if (p > pt) then
       z = (Tv0/gamma)*(1-(p/p0)**((Rd*gamma)/g))
       q_local = q0*exp(-z/zq1)*exp(-(z/zq2)**2)
       Tv = Tv0 - gamma*z
@@ -70,15 +86,60 @@ contains
     type(ty_gas_concs),     optional, &
                             intent(inout) :: gas_concs
     character(len=128)                    :: error_msg
+    ! ----------------------------------
+    integer :: nlay
+    real(wp), dimension(size(p)) :: q, o3
+    ! ----------------------------------
+    error_msg = ""
+    nlay = size(p)
+    if(.not. extents_are(temp, nlay)) &
+      error_msg = "make_rcemip_profile: p, temp have different lengths"
+    if(.not. extents_are(z,    nlay)) &
+      error_msg = "make_rcemip_profile: p, z    have different lengths"
+    if(len_trim(error_msg) /= 0) return
 
-
+    call zt_given_p(p, z, temp, q, o3)
     if(present(gas_concs)) then
-      call gas_concs%reset()
+      error_msg = gas_concs%init(rcemip_gases)
+      ! Scalars
       error_msg = gas_concs%set_vmr("co2", chi_co2)
       error_msg = gas_concs%set_vmr("ch4", chi_ch4)
       error_msg = gas_concs%set_vmr("n2o", chi_n2o)
-      ! Don't forget water vapor, ozone
+      ! Profiles
+      error_msg = gas_concs%set_vmr("h2o", q)
+      error_msg = gas_concs%set_vmr("o3" , o3)
+      error_msg = gas_concs%set_vmr("o2" , .21_wp)
     end if
+    print *, "tropopause p", p0*(Tvt/Tv0)**(g/(Rd*gamma))
   end function make_rcemip_profile_given_p
+  ! ------------------------------------------------------------------------------
+  function make_rcemip_profiles(p_lay, p_lev, t_lay, z_lay, gas_concs, p_min) result(error_msg)
+    real(wp), dimension(:), intent(  out) :: p_lay, p_lev, t_lay, z_lay
+    type(ty_gas_concs),     intent(inout) :: gas_concs
+    real(wp),     optional, intent(in   )    :: p_min
+    character(len=128)                    :: error_msg
+    ! ----------------------------------
+    real(wp) :: p_top, t_lev(size(p_lev))
+    integer  :: i, nlay
+    ! ----------------------------------
+    error_msg = ""
+    nlay = size(p_lay)
+    if(.not. extents_are(t_lay, nlay)) &
+      error_msg = "make_rcemip_profile: p_lay, t_lay have different lengths"
+    if(.not. extents_are(z_lay, nlay)) &
+      error_msg = "make_rcemip_profile: p_lay, z_lay have different lengths"
+    if(.not. extents_are(p_lev, nlay+1)) &
+      error_msg = "make_rcemip_profile: p_lev should be 1 element longer than p_lay"
+    if(len_trim(error_msg) /= 0) return
+
+    p_top = 1. ! Min RRTMGP pressure at this time is 1 Pa
+    if(present(p_min)) p_top = p_min
+    ! Equal spacing in pressure
+    p_lev = [(p_top + (p0 - p_top)/nlay * i, i = 0, nlay)]
+    ! Layer center is mean pressure
+    p_lay = 0.5_wp * (p_lev(1:nlay) + p_lev(2:))
+
+    error_msg = make_rcemip_profile_given_p(p_lay, t_lay, z_lay, gas_concs)
+  end function make_rcemip_profiles
   ! ------------------------------------------------------------------------------
 end module mo_rcemip_profiles

--- a/tests/test_zenith_angle_spherical_correction.F90
+++ b/tests/test_zenith_angle_spherical_correction.F90
@@ -40,7 +40,7 @@ program test_solar_zenith_angle
                                  p_lev(ncol, nlay+1)
   real(wp), dimension(ncol, nlay+1), target &
                               :: flux_up, flux_dn, flux_dir
-  logical(wl)                 :: top_at_1
+  logical                     :: top_at_1
   character(len=128)          :: k_dist_file = "../rrtmgp/data/rrtmgp-data-sw-g112-210809.nc"
   real(wp), dimension(:,:), allocatable &
                               :: toa_flux, sfc_alb_dir, sfc_alb_dif

--- a/tests/test_zenith_angle_spherical_correction.F90
+++ b/tests/test_zenith_angle_spherical_correction.F90
@@ -22,9 +22,11 @@ program test_solar_zenith_angle
   use mo_rte_sw,             only: rte_sw
   use mo_load_coefficients,  only: load_and_init
   use mo_heating_rates,      only: compute_heating_rate
+  implicit none
 
-  integer            :: i
-  integer, parameter :: nlay = 80, ncol = 4
+  integer             :: i, icol, ilay, nbnd, ngpt
+  integer,  parameter :: nlay = 80, ncol = 4
+  real(wp), parameter :: geometric_height = 60000._wp ! m
   real(wp), dimension(ncol        ) :: refAlt, refMu
   real(wp), dimension(ncol, 0:nlay) ::    alt,    mu
 
@@ -45,68 +47,86 @@ program test_solar_zenith_angle
   !
   ! Geometric calculation
   !
-  print *, "Geometry "
-  refAlt(:) = nlay * 1000._wp   ! Reference altitude is TOA
+  print *, "Example geometry calculation"
+  refAlt(:) = geometric_height  ! Reference altitude is TOA
   refMu (:) = .02
-  alt =  spread([(i, i = 0, nlay)] * 1000._wp, dim = 1, ncopies=ncol)
+  alt =  spread([(geometric_height/nlay * i, i = 0, nlay)], dim = 1, ncopies=ncol)
   call stop_on_err(zenith_angle_with_height(refAlt, refMu, alt, mu))
-  print *, "alt     mu0"
+  print *, "alt(km)     mu0"
   do i = nlay, 0, -1
-    print *, int(alt(1,i)/1000._wp), mu(1,i)
+    print '(f6.2, 6x, f6.4)', alt(1,i)/1000._wp, mu(1,i)
   end do
 
   !
   ! fluxes
+  !
+  ! Xxample profiles - all identical
   !
   call stop_on_err(make_rcemip_profiles(p_lay(1,:), p_lev(1,:), t_lay(1,:), z_lay(1,:), gas_concs))
   p_lay = spread(p_lay(1,:), dim=1, ncopies=ncol)
   t_lay = spread(t_lay(1,:), dim=1, ncopies=ncol)
   z_lay = spread(z_lay(1,:), dim=1, ncopies=ncol)
   p_lev = spread(p_lev(1,:), dim=1, ncopies=ncol)
-  top_at_1 = p_lay(1, 1) < p_lay(1,nlay)
-  print *, "Top is at 1? ", top_at_1
-
+  !
+  ! Initialize gas optics, optical properties variables
+  !
   call load_and_init(gas_optics, k_dist_file, gas_concs)
-  print *, "temperature limits (K):", gas_optics%get_temp_min(),  gas_optics%get_temp_max()
-
   call stop_on_err(atmos%alloc_2str(ncol, nlay, gas_optics))
   if(gas_optics%source_is_internal()) call stop_on_err("k-distribution file is for the longwave")
   nbnd = gas_optics%get_nband()
   ngpt = gas_optics%get_ngpt()
-
+  !
+  ! Compute gas optics and boundary conditions
+  !
   allocate(toa_flux(ncol, ngpt))
   call stop_on_err(gas_optics%gas_optics(p_lay, p_lev, &
                                          t_lay,        &
                                          gas_concs,    &
                                          atmos,        &
                                          toa_flux))
-
+  !
+  ! Set boundary conditions for fluxes
+  !
   allocate(sfc_alb_dir(nbnd, ncol), sfc_alb_dif(nbnd, ncol))
   sfc_alb_dir = 0._wp
   sfc_alb_dif = 0._wp
   fluxes%flux_up     => flux_up (:,:)
   fluxes%flux_dn     => flux_dn (:,:)
   fluxes%flux_dn_dir => flux_dir(:,:)
-
-  call stop_on_err(zenith_angle_with_height(z_lay(:,1), [0.01_wp, 0.02_wp, 0.03_wp, 0.04_wp], z_lay, mu0))
+  !
+  ! Set small solar zenith angles, varying by column; compute fluxes and heating rates
+  !
+  call stop_on_err(zenith_angle_with_height(z_lay(:,1), 3 * [0.01_wp, 0.02_wp, 0.03_wp, 0.04_wp], z_lay, mu0))
+  top_at_1 = p_lay(1, 1) < p_lay(1,nlay)
   call stop_on_err(rte_sw(atmos, top_at_1, &
                           mu0,   toa_flux, &
                           sfc_alb_dir, sfc_alb_dif, &
                           fluxes))
-  call stop_on_err(compute_heating_rate(flux_up, flux_dn, p_lev, heating_rate))
+  call stop_on_err(compute_heating_rate(flux_up, flux_dn, flux_dir, p_lev, mu0, heating_rate))
 
-  write(*, '("plev (Pa)  play (Pa)    Tlay (K) zlay (m)  flux_dir/dn/up")')
-  write(*, '(f7.0, 33x, 4(5x, f5.0), "  dir")')  p_lev(1,1), flux_dir(:,1)
-  write(*, '(      40x, 4(5x, f5.0), "  dn" )')              flux_dn (:,1)
-  write(*, '(      40x, 4(5x, f5.0), "  up" )')              flux_up (:,1)
+  !
+  ! Text output, top to bottom, levels and layers interleaved
+  !
+  print *, "************************************************************************************"
+  print *, "Flux calculation: ", ncol, " columns"
+  print *, "Pressures and fluxes x3 at levels interleaved with "
+  print *, "    p, t, z, mu0, heating rate on layers"
+  print *
+  print '("plev (Pa)                     flux/heating rate")'
+  print '(f7.0, 33x, 4(5x, f6.2), "  dir")',   p_lev(1,1), flux_dir(:,1)
+  print '(      40x, 4(5x, f6.2), "  dn" )',               flux_dn (:,1)
+  print '(      40x, 4(5x, f6.2), "  up" )',               flux_up (:,1)
   do i = 1, nlay
-    write(*, '(6x, 3(4x, f7.0), 4(4x, f5.2))') p_lay(1,i), t_lay(1,i), z_lay(1,i), &
-                                               heating_rate(:,i) * 86400._wp
-    write(*, '(f7.0, 33x, 4(5x, f5.2), "  dir")')   p_lev(1,i+1), flux_dir(:,i+1)
-    write(*, '(      40x, 4(5x, f5.2), "  dn" )')                 flux_dn (:,i+1)
-    write(*, '(      40x, 4(5x, f5.2), "  up" )')                 flux_up (:,i+1)
+    print '(6x, " p_lay:", f7.0, " t_lay: ", f7.0, " z_lay: ", f7.0)', p_lay(1,i), t_lay(1,i), z_lay(1,i)
+    print '(6x, " mu0:          ", 4(4x, f7.4))', mu0(:,i)
+    print '(6x, " heating rate: ", 4(4x, f7.4))', heating_rate(:,i) * 86400._wp
+    if(i > 1) then
+      if(any(mu0(:, i) > epsilon(mu0) .neqv. mu0(:, i-1) > epsilon(mu0))) &
+      print *, "************ mu0 sign change "
+    end if
+    print '(f7.0, 33x, 4(5x, f6.2), "  dir")',   p_lev(1,i+1), flux_dir(:,i+1)
+    print '(      40x, 4(5x, f6.2), "  dn" )',                 flux_dn (:,i+1)
+    print '(      40x, 4(5x, f6.2), "  up" )',                 flux_up (:,i+1)
   end do
-
-
 
 end program test_solar_zenith_angle

--- a/tests/test_zenith_angle_spherical_correction.F90
+++ b/tests/test_zenith_angle_spherical_correction.F90
@@ -10,20 +10,103 @@ subroutine stop_on_err(error_msg)
 end subroutine stop_on_err
 ! ------------------------------------------------------------------------------
 program test_solar_zenith_angle
-  use mo_rte_kind,                          only: wp, wl
-  use mo_zenith_angle_spherical_correction, only: zenith_angle_with_height
+  use mo_rte_kind,           only: wp, wl
+  use mo_zenith_angle_spherical_correction, &
+                             only: zenith_angle_with_height
 
-  integer, parameter :: nlay = 80
-  real(wp), dimension(1        ) :: refAlt, refMu
-  real(wp), dimension(1, 0:nlay) ::    alt,    mu
+  use mo_rcemip_profiles,    only: make_rcemip_profiles
+  use mo_gas_concentrations, only: ty_gas_concs
+  use mo_gas_optics_rrtmgp,  only: ty_gas_optics_rrtmgp
+  use mo_optical_props,      only: ty_optical_props_2str
+  use mo_fluxes,             only: ty_fluxes_broadband
+  use mo_rte_sw,             only: rte_sw
+  use mo_load_coefficients,  only: load_and_init
+  use mo_heating_rates,      only: compute_heating_rate
+
   integer            :: i
+  integer, parameter :: nlay = 80, ncol = 4
+  real(wp), dimension(ncol        ) :: refAlt, refMu
+  real(wp), dimension(ncol, 0:nlay) ::    alt,    mu
 
+  type(ty_gas_concs)          :: gas_concs
+  type(ty_gas_optics_rrtmgp)  :: gas_optics
+  type(ty_optical_props_2str) :: atmos
+  type(ty_fluxes_broadband)   :: fluxes
+  real(wp)                    :: p_lay(ncol, nlay), t_lay(ncol, nlay), &
+                                 z_lay(ncol, nlay), mu0  (ncol, nlay), &
+                                 heating_rate(ncol, nlay),             &
+                                 p_lev(ncol, nlay+1)
+  real(wp), dimension(ncol, nlay+1), target &
+                              :: flux_up, flux_dn, flux_dir
+  logical(wl)                 :: top_at_1
+  character(len=128)          :: k_dist_file = "../rrtmgp/data/rrtmgp-data-sw-g112-210809.nc"
+  real(wp), dimension(:,:), allocatable &
+                              :: toa_flux, sfc_alb_dir, sfc_alb_dif
+  !
+  ! Geometric calculation
+  !
+  print *, "Geometry "
   refAlt(:) = nlay * 1000._wp   ! Reference altitude is TOA
   refMu (:) = .02
-  alt(1,:) =  [(i, i = 0, nlay)] * 1000._wp
+  alt =  spread([(i, i = 0, nlay)] * 1000._wp, dim = 1, ncopies=ncol)
   call stop_on_err(zenith_angle_with_height(refAlt, refMu, alt, mu))
   print *, "alt     mu0"
   do i = nlay, 0, -1
     print *, int(alt(1,i)/1000._wp), mu(1,i)
   end do
+
+  !
+  ! fluxes
+  !
+  call stop_on_err(make_rcemip_profiles(p_lay(1,:), p_lev(1,:), t_lay(1,:), z_lay(1,:), gas_concs))
+  p_lay = spread(p_lay(1,:), dim=1, ncopies=ncol)
+  t_lay = spread(t_lay(1,:), dim=1, ncopies=ncol)
+  z_lay = spread(z_lay(1,:), dim=1, ncopies=ncol)
+  p_lev = spread(p_lev(1,:), dim=1, ncopies=ncol)
+  top_at_1 = p_lay(1, 1) < p_lay(1,nlay)
+  print *, "Top is at 1? ", top_at_1
+
+  call load_and_init(gas_optics, k_dist_file, gas_concs)
+  print *, "temperature limits (K):", gas_optics%get_temp_min(),  gas_optics%get_temp_max()
+
+  call stop_on_err(atmos%alloc_2str(ncol, nlay, gas_optics))
+  if(gas_optics%source_is_internal()) call stop_on_err("k-distribution file is for the longwave")
+  nbnd = gas_optics%get_nband()
+  ngpt = gas_optics%get_ngpt()
+
+  allocate(toa_flux(ncol, ngpt))
+  call stop_on_err(gas_optics%gas_optics(p_lay, p_lev, &
+                                         t_lay,        &
+                                         gas_concs,    &
+                                         atmos,        &
+                                         toa_flux))
+
+  allocate(sfc_alb_dir(nbnd, ncol), sfc_alb_dif(nbnd, ncol))
+  sfc_alb_dir = 0._wp
+  sfc_alb_dif = 0._wp
+  fluxes%flux_up     => flux_up (:,:)
+  fluxes%flux_dn     => flux_dn (:,:)
+  fluxes%flux_dn_dir => flux_dir(:,:)
+
+  call stop_on_err(zenith_angle_with_height(z_lay(:,1), [0.01_wp, 0.02_wp, 0.03_wp, 0.04_wp], z_lay, mu0))
+  call stop_on_err(rte_sw(atmos, top_at_1, &
+                          mu0,   toa_flux, &
+                          sfc_alb_dir, sfc_alb_dif, &
+                          fluxes))
+  call stop_on_err(compute_heating_rate(flux_up, flux_dn, p_lev, heating_rate))
+
+  write(*, '("plev (Pa)  play (Pa)    Tlay (K) zlay (m)  flux_dir/dn/up")')
+  write(*, '(f7.0, 33x, 4(5x, f5.0), "  dir")')  p_lev(1,1), flux_dir(:,1)
+  write(*, '(      40x, 4(5x, f5.0), "  dn" )')              flux_dn (:,1)
+  write(*, '(      40x, 4(5x, f5.0), "  up" )')              flux_up (:,1)
+  do i = 1, nlay
+    write(*, '(6x, 3(4x, f7.0), 4(4x, f5.2))') p_lay(1,i), t_lay(1,i), z_lay(1,i), &
+                                               heating_rate(:,i) * 86400._wp
+    write(*, '(f7.0, 33x, 4(5x, f5.2), "  dir")')   p_lev(1,i+1), flux_dir(:,i+1)
+    write(*, '(      40x, 4(5x, f5.2), "  dn" )')                 flux_dn (:,i+1)
+    write(*, '(      40x, 4(5x, f5.2), "  up" )')                 flux_up (:,i+1)
+  end do
+
+
+
 end program test_solar_zenith_angle

--- a/tests/test_zenith_angle_spherical_correction.F90
+++ b/tests/test_zenith_angle_spherical_correction.F90
@@ -1,0 +1,29 @@
+subroutine stop_on_err(error_msg)
+  use iso_fortran_env, only : error_unit
+  character(len=*), intent(in) :: error_msg
+
+  if(error_msg /= "") then
+    write (error_unit,*) trim(error_msg)
+    write (error_unit,*) "test_solar_zenith_angle stopping"
+    error stop 1
+  end if
+end subroutine stop_on_err
+! ------------------------------------------------------------------------------
+program test_solar_zenith_angle
+  use mo_rte_kind,                          only: wp, wl
+  use mo_zenith_angle_spherical_correction, only: zenith_angle_with_height
+
+  integer, parameter :: nlay = 80
+  real(wp), dimension(1        ) :: refAlt, refMu
+  real(wp), dimension(1, 0:nlay) ::    alt,    mu
+  integer            :: i
+
+  refAlt(:) = nlay * 1000._wp   ! Reference altitude is TOA
+  refMu (:) = .02
+  alt(1,:) =  [(i, i = 0, nlay)] * 1000._wp
+  call stop_on_err(zenith_angle_with_height(refAlt, refMu, alt, mu))
+  print *, "alt     mu0"
+  do i = nlay, 0, -1
+    print *, int(alt(1,i)/1000._wp), mu(1,i)
+  end do
+end program test_solar_zenith_angle

--- a/tests/validation-plots.py
+++ b/tests/validation-plots.py
@@ -155,7 +155,7 @@ if __name__ == '__main__':
             plt.close()
         ########################################################################
         # Shortwave
-        #   These are in W/m2 so profiles with high run count for more.
+        #   These are in W/m2 so profiles with high sun count for more.
         #   Would they be better scaled to incoming solar flux?
         ########################################################################
         #


### PR DESCRIPTION
Allows for solar zenith angle (SZA = acos(mu0)) to vary by height within each column, motivated by "[A round earth for climate models](https://doi.org/10.1073/pnas.1908198116)." In the radiative transfer solvers the reflectivity and transmissivity of each layer depends on the (local in height) mu0; where the sun is below the horizon (mu0 <=0) these are set to 0. This means that heating rates in the last sunlight layer have to consider only the divergence of diffuse radiation (see the example in `extensions/mo_heating_rates.F90`). Incident flux is determined by mu0 at the top of the atmosphere. 

`extensions/mo_zenith_angle_spherical_correction.F90` provides a way to calculate mu0(z) considering only geometric effects. I hope to add the ability to account for the changing index of refraction. 

`tests/test_zenith_angle_correction.F90` is a quick-and-dirty test (streams of text output) of the feature including the heating rate calculations. This makes us of `tests/mo_recmip_profiles.F90` which creates example problems for arbitrary pressure grids based on the [protocol](https://doi.org/10.5194/gmd-11-793-2018) for the [Radiative-Convective Equilibrium MIP](https://myweb.fsu.edu/awing/rcemip.html)