### PR TITLE
32-bit physics with FV3_RAP

### DIFF
--- a/rte/mo_rte_kind.F90
+++ b/rte/mo_rte_kind.F90
@@ -26,7 +26,11 @@ module mo_rte_kind
   !
   ! Floating point working precision
   !
+#ifdef RTE_USE_SP
+  integer, parameter :: wp = sp
+#else
   integer, parameter :: wp = dp
+#endif
 
   !
   ! Logical - for use with kernels


### PR DESCRIPTION
This adds support for 32-bit physics to the FV3, based on prior work on the Neptune model. The 64-bit physics should not change results. The only change in this repository is to add a flag to enable single precision. The code for that was copied from the authoritative branch.

See the top-level PR here for details:

https://github.com/ufs-community/ufs-weather-model/pull/1215

The issue for this is here:

https://github.com/ufs-community/ufs-weather-model/issues/1288