### PR TITLE
Unused local variables removed

### DIFF
--- a/rrtmgp/kernels/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels/mo_gas_optics_kernels.F90
@@ -527,7 +527,7 @@ contains
     ! -----------------
     ! local variables
     real(wp) :: k(ngpt) ! rayleigh scattering coefficient
-    integer  :: icol, ilay, iflav, ibnd, igpt, gptS, gptE
+    integer  :: icol, ilay, iflav, ibnd, gptS, gptE
     integer  :: itropo
     ! -----------------
 

--- a/rrtmgp/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp/mo_gas_optics_rrtmgp.F90
@@ -1127,7 +1127,6 @@ contains
     real(wp), dimension(:,:,:),   intent(in) :: vmr_ref
     real(wp), dimension(:,:,:,:), intent(in) :: kmajor
     real(wp), dimension(:,:,:),   intent(in) :: kminor_lower, kminor_upper
-    real(wp), dimension(:,:,:), allocatable  :: kminor_lower_t, kminor_upper_t
     character(len=*),   dimension(:), &
                                   intent(in) :: gas_minor, &
                                                 identifier_minor


### PR DESCRIPTION
Hi, I removed some unused local variables.

There are some more possibilities for a further clean-up:

- The functions `interpolate2D` and `interpolate3D` are unused. Can they be removed or are they meant to evolve?
- There are quite a few unused dummy arguments. Can they all be removed from the function calls or are they still there for compatibility reasons? Example: Dummy argument `gas_names` in subroutine `reduce_minor_arrays`.