### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -25,7 +25,6 @@ jobs:
         - fortran-compiler: nvfortran
           fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
           image: "earthsystemradiation/rte-rrtmgp-ci:nvfortran"
-        - netcdf-fortran: /opt/netcdf-fortran
     container:
       image: ${{ matrix.image }}
     env:
@@ -34,7 +33,7 @@ jobs:
       FCFLAGS: ${{ matrix.fcflags }}
       # Make variables:
       NCHOME: /dummy
-      NFHOME: ${{ matrix.netcdf-fortran }}
+      NFHOME: /opt/netcdf-fortran
       RRTMGP_ROOT: ${{ github.workspace }}
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -20,10 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fortran-compiler: [ifort, nvfortran]
+        fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, openacc]
         include:
         - fortran-compiler: ifort
+          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+          image: "earthsystemradiation/rte-rrtmgp-ci:ifort"
+        - fortran-compiler: ifx
           fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
           image: "earthsystemradiation/rte-rrtmgp-ci:ifort"
         - fortran-compiler: nvfortran

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -9,7 +9,10 @@ on:
 
 defaults:
   run:
-    shell: bash
+    # Enable compilers by using login shell:
+    #   Contrary to what the documentation says, GitHub Actions override the
+    #   entrypoint: https://github.com/actions/runner/issues/1964
+    shell: bash -leo pipefail {0}
 
 jobs:
   Containerized-CI:
@@ -26,8 +29,7 @@ jobs:
         - fortran-compiler: nvfortran
           fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
           image: "earthsystemradiation/rte-rrtmgp-ci:nvfortran"
-        - netcdf-c: /home/runner/netcdf-c
-        - netcdf-fortran: /home/runner/netcdf-fortran
+        - netcdf-fortran: /opt/netcdf-fortran
     container:
       image: ${{ matrix.image }}
     env:
@@ -35,7 +37,7 @@ jobs:
       FC: ${{ matrix.fortran-compiler }}
       FCFLAGS: ${{ matrix.fcflags }}
       # Make variables:
-      NCHOME: ${{ matrix.netcdf-c }}
+      NCHOME: /dummy
       NFHOME: ${{ matrix.netcdf-fortran }}
       RRTMGP_ROOT: ${{ github.workspace }}
       RTE_KERNELS: ${{ matrix.rte-kernels }}
@@ -47,16 +49,6 @@ jobs:
     # Checks-out repository under $GITHUB_WORKSPACE
     #
     - uses: actions/checkout@v3
-    #
-    # Install Zstd
-    #
-    - name: Install Zstd
-      run: |
-        # We skip 'apt-get update' to keep this step lightweight. However, that
-        # might lead to a failure, which we tolerate because the only reason we
-        # run it is to make cache files compatible across workflows.
-        # TODO: update the containers so that we could skip the following:
-        apt-get install zstd || true
     #
     # Cache RFMIP files
     #
@@ -80,14 +72,6 @@ jobs:
             cp "${file}" "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/"
           fi
         done
-    #
-    # Finalize build environment
-    #
-    - name: Finalize build environment
-      if: contains('ifort ifx', matrix.fortran-compiler)
-      run: |
-        # TODO: update the Intel container so that we do not have to the following:
-        echo "BASH_ENV=/opt/intel/oneapi/setvars.sh" >> "${GITHUB_ENV}"
     #
     # Build libraries, examples and tests
     #

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -1,11 +1,15 @@
 name: Continuous integration in a box
-on: 
-  push: 
-    branches-ignore:    
-      - documentation
-  pull_request: 
-    branches-ignore:    
-      - documentation
+on:
+  push:
+    branches-ignore:
+    - documentation
+  pull_request:
+    branches-ignore:
+    - documentation
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   Containerized-CI:
@@ -13,72 +17,107 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        fortran-compiler: [ifort, nvfortran]
         rte-kernels: [default, openacc]
-        container: ["earthsystemradiation/rte-rrtmgp-ci:ifort","earthsystemradiation/rte-rrtmgp-ci:nvfortran"]
+        include:
+        - fortran-compiler: ifort
+          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+          image: "earthsystemradiation/rte-rrtmgp-ci:ifort"
+        - fortran-compiler: nvfortran
+          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+          image: "earthsystemradiation/rte-rrtmgp-ci:nvfortran"
+        - netcdf-c: /home/runner/netcdf-c
+        - netcdf-fortran: /home/runner/netcdf-fortran
     container:
-      image: ${{ matrix.container }}
+      image: ${{ matrix.image }}
     env:
-      NCHOME: /home/runner/netcdf-c
-      NFHOME: /home/runner/netcdf-fortran
-      RFMIP_DIR: /home/runner/rfmip-files
+      # Core variables:
+      FC: ${{ matrix.fortran-compiler }}
+      FCFLAGS: ${{ matrix.fcflags }}
+      # Make variables:
+      NCHOME: ${{ matrix.netcdf-c }}
+      NFHOME: ${{ matrix.netcdf-fortran }}
+      RRTMGP_ROOT: ${{ github.workspace }}
+      RTE_KERNELS: ${{ matrix.rte-kernels }}
+      RUN_CMD:
+      # Auxiliary variables:
+      RFMIP_CACHEDIR: /home/runner/rfmip-files
     steps:
-    ############################################################################
-    # Checks out repository under $GITHUB_WORKSPACE
-    - name: Check out code
-      uses: actions/checkout@v3
-    - name: Environmental variables
-      # This might be able to be set in the ENV section above
-      run: echo "RRTMGP_ROOT=${GITHUB_WORKSPACE}"        >> $GITHUB_ENV
-    - name: Environmental variables - ifort
-      if: contains(matrix.container, 'ifort')
-      run: echo "FCFLAGS=-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08" >> $GITHUB_ENV
-    - name: Environmental variables - nvfortran
-      if: contains(matrix.container, 'nvfortran')
-      run: echo "FCFLAGS=-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk" >> $GITHUB_ENV
-
-    - name: Make library, examples, tests
-      shell: bash
-      env:
-        RTE_KERNELS: ${{ matrix.rte-kernels }}
+    #
+    # Checks-out repository under $GITHUB_WORKSPACE
+    #
+    - uses: actions/checkout@v3
+    #
+    # Install Zstd
+    #
+    - name: Install Zstd
       run: |
-        source /opt/intel/oneapi/setvars.sh || true
-        cd ${RRTMGP_ROOT}
-        ${FC} --version
-        make libs
-        make -C build separate-libs
-    ############################################################################
+        # We skip 'apt-get update' to keep this step lightweight. However, that
+        # might lead to a failure, which we tolerate because the only reason we
+        # run it is to make cache files compatible across workflows.
+        # TODO: update the containers so that we could skip the following:
+        apt-get install zstd || true
+    #
+    # Cache RFMIP files
+    #
     - name: Cache RFMIP files
-      id: cache-rfmip-files
       uses: actions/cache@v3
       with:
-        path: /home/runner/rfmip-files # Same as #{RFMIP_DIR}
+        path: ${{ env.RFMIP_CACHEDIR }}
         key: rfmip-files
-
+    #
+    # Stage RFMIP files
+    #
     - name: Stage RFMIP files
-      if: steps.cache-rfmip-files.outputs.cache-hit != 'true'
       run: |
-        mkdir -p ${RFMIP_DIR}
-        cd ${RFMIP_DIR}
-        python ${RRTMGP_ROOT}/examples/rfmip-clear-sky/stage_files.py
-    ############################################################################
-    - name: Run examples, tests
-      shell: bash
-      env:
-        LD_LIBRARY_PATH: /home/runner/netcdf-c/lib
+        if test ! -d "${RFMIP_CACHEDIR}"; then
+          mkdir -p "${RFMIP_CACHEDIR}" && cd "${RFMIP_CACHEDIR}"
+          python "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/stage_files.py"
+        fi
+        for file in "${RFMIP_CACHEDIR}"/*; do
+          if test ! -d "${file}"; then
+            echo "copying '${file}'..."
+            cp "${file}" "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/"
+          fi
+        done
+    #
+    # Finalize build environment
+    #
+    - name: Finalize build environment
+      if: contains('ifort ifx', matrix.fortran-compiler)
       run: |
-        source /opt/intel/oneapi/setvars.sh || true
-        export LD_LIBRARY_PATH=${NFHOME}/lib:${LD_LIBRARY_PATH}
-        make tests
-    - name: Comparison
+        # TODO: update the Intel container so that we do not have to the following:
+        echo "BASH_ENV=/opt/intel/oneapi/setvars.sh" >> "${GITHUB_ENV}"
+    #
+    # Build libraries, examples and tests
+    #
+    - name: Build libraries, examples and tests
+      run: |
+        $FC --version
+        make libs
+        make -C build separate-libs
+    #
+    # Run examples and tests
+    #
+    - name: Run examples and tests
+      run: make tests
+    #
+    # Compare the results
+    #
+    - name: Compare the results
       run: make check
-    ############################################################################
-    - name: Validation plots
-      if: contains(matrix.container, 'ifort') && contains(matrix.rte-kernels, 'default')
-      run: |
-        cd ${RRTMGP_ROOT}/tests
-        python validation-plots.py
-    - name: Upload plots
-      if: contains(matrix.container, 'ifort') && contains(matrix.rte-kernels, 'default')
+    #
+    # Generate validation plots
+    #
+    - name: Generate validation plots
+      if: matrix.fortran-compiler == 'ifort' && matrix.rte-kernels == 'default'
+      working-directory: tests
+      run: python validation-plots.py
+    #
+    # Upload validation plots
+    #
+    - name: Upload validation plots
+      if: matrix.fortran-compiler == 'ifort' && matrix.rte-kernels == 'default'
       uses: actions/upload-artifact@v3
       with:
         name: valdiation-plot

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -7,13 +7,6 @@ on:
     branches-ignore:
     - documentation
 
-defaults:
-  run:
-    # Enable compilers by using login shell:
-    #   Contrary to what the documentation says, GitHub Actions override the
-    #   entrypoint: https://github.com/actions/runner/issues/1964
-    shell: bash -leo pipefail {0}
-
 jobs:
   Containerized-CI:
     runs-on: ubuntu-22.04

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   Containerized-CI:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,13 +46,7 @@ jobs:
     - name: Synchronize the package index
       run: sudo apt-get update
     #
-    # Install Gfortran 10
-    #
-    - name: Install Gfortran 10
-      if: matrix.fortran-compiler == 'gfortran-10'
-      run: sudo apt-get install gfortran-10
-    #
-    # Install NetCDF-Fortran (compatible with both compilers)
+    # Install NetCDF-Fortran (compatible with all compilers)
     #
     - name: Install NetCDF-Fortran
       run: sudo apt-get install libnetcdff-dev

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,16 +20,13 @@ jobs:
       matrix:
         fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
         rte-kernels: [default, openacc]
-        include:
-        - fcflags: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DRTE_USE_CBOOL"
-        - netcdf-fortran: /usr
     env:
       # Core variables:
       FC: ${{ matrix.fortran-compiler }}
-      FCFLAGS: ${{ matrix.fcflags }}
+      FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DRTE_USE_CBOOL"
       # Make variables:
       NCHOME: /dummy
-      NFHOME: ${{ matrix.netcdf-fortran }}
+      NFHOME: /usr
       RRTMGP_ROOT: ${{ github.workspace }}
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         miniforge-version: latest
         activate-environment: rte_rrtmgp_test
-        environment-file: environment.yml
+        environment-file: environment-noplots.yml
         python-version: 3.9
         auto-activate-base: false
         # Use the cache properly:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,121 +1,73 @@
 name: Continuous Integration
-on: 
-  push: 
-    branches-ignore:    
-      - documentation
-  pull_request: 
-    branches-ignore:    
-      - documentation
+on:
+  push:
+    branches-ignore:
+    - documentation
+  pull_request:
+    branches-ignore:
+    - documentation
+
+defaults:
+  run:
+    # Enable Conda environment by using the login shell:
+    shell: bash -leo pipefail {0}
 
 jobs:
   CI:
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash -l {0}
     strategy:
+      fail-fast: false
       matrix:
-        fortran-compiler:  [gfortran-9, gfortran-10]
+        fortran-compiler: [gfortran-9, gfortran-10]
         rte-kernels: [default, openacc]
+        include:
+        - fcflags: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DRTE_USE_CBOOL"
+        - netcdf-fortran: /usr
     env:
+      # Core variables:
       FC: ${{ matrix.fortran-compiler }}
-      FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DRTE_USE_CBOOL"
-      CC: gcc
-      NCHOME: /home/runner/netcdf-c
-      NFHOME: /home/runner/netcdf-fortran
-      RFMIP_DIR: /home/runner/rfmip-files
+      FCFLAGS: ${{ matrix.fcflags }}
+      # Make variables:
+      NCHOME: /dummy
+      NFHOME: ${{ matrix.netcdf-fortran }}
+      RRTMGP_ROOT: ${{ github.workspace }}
+      RTE_KERNELS: ${{ matrix.rte-kernels }}
+      RUN_CMD:
+      # Auxiliary variables:
+      RFMIP_CACHEDIR: /home/runner/rfmip-files
     steps:
-    - name: Update system packages
+    #
+    # Checks-out repository under $GITHUB_WORKSPACE
+    #
+    - uses: actions/checkout@v3
+    #
+    # Synchronize the package index
+    #
+    - name: Synchronize the package index
       run: sudo apt-get update
-    ############################################################################
     #
-    # Compilers....
+    # Install Gfortran 10
     #
-    # Gfortran 10 not available in Github CI stack, so install
+    - name: Install Gfortran 10
+      if: matrix.fortran-compiler == 'gfortran-10'
+      run: sudo apt-get install gfortran-10
     #
-    - name: gfortran-10 setup compiler
-      if: contains(matrix.fortran-compiler, 'gfortran-10')
-      run: |
-        sudo apt-get install gfortran-10 gcc-10
-        echo "CC=gcc-10" >> $GITHUB_ENV
-
-    ############################################################################
+    # Install NetCDF-Fortran (compatible with both compilers)
     #
-    # Netcdf C and Fortran
+    - name: Install NetCDF-Fortran
+      run: sudo apt-get install libnetcdff-dev
     #
-    - name: Install HDF5 library
-      run: |
-        sudo apt-get install libhdf5-dev libcurl4-gnutls-dev hdf5-helpers
-        dpkg -L libhdf5-dev
-
-    # Skipping this for now - netCDF configure doesn't see the HDF libararies
-    - name: cache-netcdf-c
-      id: cache-netcdf-c
+    # Cache Conda packages
+    #
+    - name: Cache Conda packages
       uses: actions/cache@v3
       with:
-        path: /home/runner/netcdf-c
-        key: netcdf-c-4.7.4a-${{ runner.os }}-${{ matrix.fortran-compiler }}
-
-    - name: Install netcdf C library from source
-      if: steps.cache-netcdf-c.outputs.cache-hit != 'true'
-      env:
-        CPPFLAGS: -I/usr/include/hdf5/serial
-        LDFLAGS: -L/usr/lib/x86_64-linux-gnu/hdf5/serial/
-      run: |
-        ${CC} --version
-        git clone https://github.com/Unidata/netcdf-c.git --branch v4.7.4
-        cd netcdf-c
-        ls /usr/include
-        ./configure --prefix=${NCHOME}
-        make -j
-        sudo make install
-
-    # Would be great to encode version info
-    - name: cache-netcdf-fortran
-      id: cache-netcdf-fortran
-      uses: actions/cache@v3
-      with:
-        path: /home/runner/netcdf-fortran
-        key: netcdf-fortran-4.5.3-${{ runner.os }}-${{ matrix.fortran-compiler }}
-
-    - name: Build NetCDF Fortran library
-      # Here too it would be nice to use the environment to specify netcdf-c location
-      env:
-        CPPFLAGS: -I/home/runner/netcdf-c/include
-        LDFLAGS: -L/home/runner/netcdf-c/lib
-        LD_LIBRARY_PATH: /home/runner/netcdf-c/lib
-        FCFLAGS: -fPIC
-      if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
-      run: |
-        echo ${TEST}
-        ${FC} --version
-        git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.5.3
-        cd netcdf-fortran
-        echo ${CPPFLAGS}
-        ./configure --prefix=${NFHOME}
-        make -j
-        sudo make install
-    ############################################################################
-    # Checks out repository under $GITHUB_WORKSPACE
-    - name: Check out code
-      uses: actions/checkout@v3
-
-    - name: Environmental variables
-      run: echo "RRTMGP_ROOT=${GITHUB_WORKSPACE}"        >> $GITHUB_ENV
-
-    - name: Make library, examples, tests
-      env:
-        RTE_KERNELS: ${{ matrix.rte-kernels }}
-      run: |
-        cd ${RRTMGP_ROOT}
-        ${FC} --version
-        make libs
-        make -C build separate-libs
-
-    ############################################################################
-    # Set up Python and packages
+        path: ~/conda_pkgs_dir
+        key: conda-pkgs
     #
-    - name: Setup conda
+    # Set up Conda
+    #
+    - name: Set up Conda
       uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-version: latest
@@ -123,28 +75,46 @@ jobs:
         environment-file: environment.yml
         python-version: 3.9
         auto-activate-base: false
-    ############################################################################
+        # Use the cache properly:
+        use-only-tar-bz2: true
+    #
+    # Cache RFMIP files
+    #
     - name: Cache RFMIP files
-      id: cache-rfmip-files
       uses: actions/cache@v3
       with:
-        path: /home/runner/rfmip-files # Same as #{RFMIP_DIR}
+        path: ${{ env.RFMIP_CACHEDIR }}
         key: rfmip-files
-
+    #
+    # Stage RFMIP files
+    #
     - name: Stage RFMIP files
-      if: steps.cache-rfmip-files.outputs.cache-hit != 'true'
       run: |
-        mkdir -p ${RFMIP_DIR}
-        cd ${RFMIP_DIR}
-        python ${RRTMGP_ROOT}/examples/rfmip-clear-sky/stage_files.py
-    ############################################################################
-    # Would be great to encode version info
-    - name: Run examples, tests
-      env:
-        LD_LIBRARY_PATH: /home/runner/netcdf-c/lib
+        if test ! -d "${RFMIP_CACHEDIR}"; then
+          mkdir -p "${RFMIP_CACHEDIR}" && cd "${RFMIP_CACHEDIR}"
+          python "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/stage_files.py"
+        fi
+        for file in "${RFMIP_CACHEDIR}"/*; do
+          if test ! -d "${file}"; then
+            echo "copying '${file}'..."
+            cp "${file}" "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/"
+          fi
+        done
+    #
+    # Build libraries, examples and tests
+    #
+    - name: Build libraries, examples and tests
       run: |
-        export LD_LIBRARY_PATH=${NFHOME}/lib:${LD_LIBRARY_PATH}
-        make tests
-    - name: Comparison
-      run: |
-        make check
+        $FC --version
+        make libs
+        make -C build separate-libs
+    #
+    # Run examples and tests
+    #
+    - name: Run examples and tests
+      run: make tests
+    #
+    # Compare the results
+    #
+    - name: Compare the results
+      run: make check

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,11 +14,11 @@ defaults:
 
 jobs:
   CI:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        fortran-compiler: [gfortran-9, gfortran-10]
+        fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
         rte-kernels: [default, openacc]
         include:
         - fcflags: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DRTE_USE_CBOOL"

--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -1,54 +1,64 @@
 name: Build and Deploy Documentation and Website
-
 on:
   push:
-    branches:    
-      - main
-      - documentation
+    branches:
+    - main
+    - documentation
 
 jobs:
   Build:
     runs-on: ubuntu-22.04
-
-    env:
-      FC: gfortran
-      GCC_V: 12
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-
-    - name: Install Dependencies Ubuntu
+    #
+    # Checks-out repository under $GITHUB_WORKSPACE
+    #
+    - uses: actions/checkout@v3
+    #
+    # Synchronize the package index
+    #
+    - name: Synchronize the package index
+      run: sudo apt-get update
+    #
+    # Install dependencies
+    #
+    - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt install -y gfortran-${GCC_V} python3-dev graphviz
-        sudo pip install ford
-
-    # Install ruby
-    - uses: ruby/setup-ruby@v1
+        sudo apt-get install graphviz
+        sudo pip install 'markdown<3.4' ford
+    #
+    # Install Ruby
+    #
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
-
-    # Setup Jekyll
-    - name: Setup Jekyll
+    #
+    # Install Jekyll
+    #
+    - name: Install Jekyll
       run: |
         cd doc/jekyll_site
         sudo gem install bundler jekyll
         bundle update
-
+    #
     # Build documentation
+    #
     - name: Build Documentation
       run: |
         cd doc
         ./build_documentation.sh -ci
-
+    #
+    # Upload documentation
+    #
     - name: Upload Documentation
       uses: actions/upload-artifact@v3
       with:
         name: documentation
         path: public/
         if-no-files-found: error
-
+    #
+    # Check broken links
+    #
     - name: Broken Link Check
       if: ${{ github.ref == 'refs/heads/main'}}
       uses: technote-space/broken-link-checker-action@v2
@@ -56,7 +66,9 @@ jobs:
         TARGET: file://${{ github.workspace }}/doc/ford_site/pages/index.html
         RECURSIVE: true
         ASSIGNEES: ${{ github.actor }}
-
+    #
+    # Deploy documentation
+    #
     - name: Deploy API Documentation
       uses: JamesIves/github-pages-deploy-action@v4.4.1
       if: ${{ github.event_name == 'push'  &&  github.ref == 'refs/heads/main' }}

--- a/.github/workflows/module_switcher
+++ b/.github/workflows/module_switcher
@@ -1,0 +1,116 @@
+switch_for_module ()
+{
+  for sfm_module in "$@"; do
+    case $sfm_module in
+      !*)
+        sfm_module=`echo $sfm_module | cut -c2-`
+        sfm_cmd="module unload $sfm_module"
+        echo "$sfm_cmd"
+        eval "$sfm_cmd"
+        continue ;;
+    esac
+
+    sfm_module_full=
+    sfm_module_short=
+    case $sfm_module in
+      */*)
+        # The module is provided with the version part:
+        sfm_module_full=$sfm_module
+        sfm_module_short=`echo $sfm_module | sed 's%/[^/]*$%%'` ;;
+      *)
+        # Only the name of the module is provided, get the default version:
+        sfm_module_full=`module show $sfm_module 2>&1 | sed -n "s%^[^ \t]*/\\($sfm_module.*\\):%\\1%p"`
+        sfm_module_short=$sfm_module ;;
+    esac
+
+    # A space-separated list of modules that are already loaded:
+    sfm_loaded_full=`module -t list 2>&1 | tr '\n' ' ' | sed 's/^.*Modulefiles://' | sed 's/(default)//g'`
+
+    # Check whether the requested module if already loaded:
+    if test -n "$sfm_module_full"; then
+      case " $sfm_loaded_full " in
+        *" $sfm_module_full "*)
+          echo "module $sfm_module is already loaded"
+          continue ;;
+      esac
+    fi
+
+    # A list of modules in conflict:
+    sfm_conflicts=`module show $sfm_module 2>&1 | sed -n 's/^conflict\(.*\)/\1/p' | tr '\n\t' '  '`
+
+    # A list of loaded modules without version parts:
+    sfm_loaded_short=`echo "$sfm_loaded_full" | sed 's%\([^ ][^ ]*\)/[^ ]*%\1%g'`
+
+    # Add the short name of the module to the list of conflicts:
+    sfm_conflicts="$sfm_conflicts $sfm_module_short"
+
+    # On a Cray system, it is important that only one PrgEnv module is loaded at
+    # a time. This is normally covered with the mutual conflict statements in
+    # the respective module files. However, that is not always the case,
+    # therefore we introduce an additional protection against two or more PrgEnv
+    # modules being loaded simultaneously: if the module we are asked to switch
+    # for starts with PrgEnv-, each of the loaded modules that starts with
+    # PrgEnv- too is added to the list of conflicts:
+    case $sfm_module_short in
+      PrgEnv-*)
+        for sfm_loaded in $sfm_loaded_short; do
+          case $sfm_loaded in
+            PrgEnv-*)
+              sfm_conflicts="$sfm_conflicts $sfm_loaded" ;;
+            *) ;;
+          esac
+        done
+      ;;
+      *) ;;
+    esac
+
+    # A list of loaded modules that are in conflict with the requested module:
+    sfm_loaded_conflicts=
+    for sfm_conflict in $sfm_conflicts""; do
+      sfm_loaded_list=
+      case $sfm_conflict in
+        */*)
+          # The conflict is specified with the version part:
+          sfm_loaded_list=$sfm_loaded_full ;;
+        *)
+          # The conflict is specified without the version part:
+          sfm_loaded_list=$sfm_loaded_short ;;
+      esac
+
+      # Check that the conflicted module is loaded:
+      case " $sfm_loaded_list " in
+        *" $sfm_conflict "*)
+          # The conflict is loaded, check whether it is already added to the
+          # list:
+          case " $sfm_loaded_conflicts " in
+            *" $sfm_conflict "*) ;;
+            *)
+              # The conflict is not in the list, append:
+              sfm_loaded_conflicts="$sfm_loaded_conflicts $sfm_conflict" ;;
+          esac
+        ;;
+      esac
+    done
+
+    # Calculate the number of modules that must be unloaded to before loading
+    # the requested module:
+    sfm_loaded_conflicts_count=`echo $sfm_loaded_conflicts | wc -w`
+
+    case $sfm_loaded_conflicts_count in
+      0)
+        # None of the conflicting modules is loaded:
+        sfm_cmd="module load $sfm_module" ;;
+      1)
+        # There is only one module that must be unloaded, use switch command:
+        sfm_cmd="module switch $sfm_loaded_conflicts $sfm_module" ;;
+      *)
+        # There is more than one module that must be unloaded, unload all of
+        # them and then load the requested one:
+        sfm_cmd="module unload $sfm_loaded_conflicts && module load $sfm_module" ;;
+    esac
+
+    echo "$sfm_cmd"
+    eval "$sfm_cmd"
+  done
+}
+

--- a/.github/workflows/module_switcher
+++ b/.github/workflows/module_switcher
@@ -1,3 +1,33 @@
+#
+# Accepts a list of environment modules and makes sure that they are
+# loaded/unloaded. The function makes it easier to manipulate modules in
+# non-interactive shell mode while transparently accounting for several common
+# defects in the configuration of the environment module system:
+#
+#   1) if a module's name is prepended with the exclamation mark ('!') on the
+#      argument list, the module is unloaded using the 'make unload' command
+#      (helps in preparing the environment using a single command);
+#
+#   2) if a module is already loaded, it does not get reloaded (some
+#      environments, e.g. Cray, are sensitive to the undocumented order of the
+#      loaded modules and keeping an already loaded module instead of reloading
+#      it is often safer);
+#
+#   3) if a module conflicts exactly one already loaded module, it gets loaded
+#      using the 'module switch' command (this is often the only tested and
+#      functional way to load a required module in some environments, e.g
+#      PrgEnv-* modules on Cray);
+#
+#   4) if a module is in conflict with several already loaded modules, all
+#      conflicting modules get unloaded first using the 'module unload' command
+#      and then the required module is loaded using the 'module load' command;
+#
+#   5) if a module's name starts with 'PrgEnv-', it is considered to be in
+#      conflict with any other module that has that prefix (on a Cray system, it
+#      is important that only one PrgEnv module is loaded at a time, which is
+#      normally covered with the mutual conflict statements in the respective
+#      module files, however, that is not always the case).
+#
 switch_for_module ()
 {
   for sfm_module in "$@"; do

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -18,22 +18,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - config_name: nvidia-gpu-acc
+        - config-name: nvidia-gpu-acc
           rte-kernels: openacc
-          compiler_modules: "PrgEnv-nvidia nvidia craype-accel-nvidia60 cdt-cuda/21.09 !cray-libsci_acc"
+          compiler-modules: "PrgEnv-nvidia nvidia craype-accel-nvidia60 cdt-cuda/21.09 !cray-libsci_acc"
           # Generic accelerator flag
           fcflags: "-O3 -acc -Mallocatable=03 -gopt"
-        - config_name: cce-cpu-icon-production
+        - config-name: cce-cpu-icon-production
           rte-kernels: default
-          compiler_modules: "PrgEnv-cray"
+          compiler-modules: "PrgEnv-cray"
           # Production flags for Icon model
           fcflags: "-hadd_paren -r am -Ktrap=divz,ovf,inv -hflex_mp=intolerant -hfp1 -hnoacc -O1,cache0"
-        - config_name: cce-gpu-openmp
+        - config-name: cce-gpu-openmp
           rte-kernels: openacc
-          compiler_modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05"
+          compiler-modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05"
           # OpenMP flags from Nichols Romero (Argonne)
           fcflags: "-hnoacc -homp -O0"
-
     env:
       # Core variables:
       FC: ftn
@@ -44,8 +43,6 @@ jobs:
       RRTMGP_ROOT: ${{ github.workspace }}
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD: "srun -C gpu -A d56 -p cscsci -t 15:00"
-      # Auxiliary variables:
-      MODULES: "daint-gpu ${{ matrix.compiler_modules }} cray-netcdf cray-hdf5"
     steps:
     #
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -60,7 +57,7 @@ jobs:
         # therefore, we use ${BASH_ENV} but only when necessary:
         BASH_ENV="${GITHUB_WORKSPACE}/.bash"
         echo "source '${GITHUB_WORKSPACE}/.github/workflows/module_switcher'" >> "${BASH_ENV}"
-        echo "switch_for_module ${MODULES}" >> "${BASH_ENV}"
+        echo "switch_for_module daint-gpu ${{ matrix.compiler-modules }} cray-netcdf cray-hdf5" >> "${BASH_ENV}"
         # Use custom Python environment:
         #   The environment can be re-generated as follows:
         #     module load cray-python

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -66,7 +66,7 @@ jobs:
         #     module load cray-python
         #     python3 -m venv /scratch/snx3000/rpincus/rte-rrtmgp-python
         #     /scratch/snx3000/rpincus/rte-rrtmgp-python/bin/pip3 install --upgrade pip
-        #     /scratch/snx3000/rpincus/rte-rrtmgp-python/bin/pip3 install netCDF4 xarray dask[array]
+        #     /scratch/snx3000/rpincus/rte-rrtmgp-python/bin/pip3 install dask[array] netCDF4 numpy xarray
         echo "PATH=\"/scratch/snx3000/rpincus/rte-rrtmgp-python/bin:\${PATH}\"" >> "${BASH_ENV}"
         # Make bash run the above on startup:
         echo "BASH_ENV=${BASH_ENV}" >> "${GITHUB_ENV}"

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -14,6 +14,7 @@ defaults:
 jobs:
   CI:
     runs-on: daint
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,16 +24,19 @@ jobs:
           compiler-modules: "PrgEnv-nvidia nvidia craype-accel-nvidia60 cdt-cuda/21.09 !cray-libsci_acc"
           # Generic accelerator flag
           fcflags: "-O3 -acc -Mallocatable=03 -gopt"
+          experimental: false
         - config-name: cce-cpu-icon-production
           rte-kernels: default
           compiler-modules: "PrgEnv-cray"
           # Production flags for Icon model
           fcflags: "-hadd_paren -r am -Ktrap=divz,ovf,inv -hflex_mp=intolerant -hfp1 -hnoacc -O1,cache0"
+          experimental: false
         - config-name: cce-gpu-openmp
           rte-kernels: openacc
           compiler-modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05"
           # OpenMP flags from Nichols Romero (Argonne)
           fcflags: "-hnoacc -homp -O0"
+          experimental: true
     env:
       # Core variables:
       FC: ftn

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -1,12 +1,15 @@
 name: Self-hosted CI
+on:
+  push:
+    branches-ignore:
+    - documentation
+  pull_request:
+    branches-ignore:
+    - documentation
 
-on: 
-  push: 
-    branches-ignore:    
-      - documentation
-  pull_request: 
-    branches-ignore:    
-      - documentation
+defaults:
+  run:
+    shell: bash
 
 jobs:
   CI:
@@ -15,87 +18,76 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - config_name: nvidia_default_gpu
-          cdt_version: cdt-cuda/21.09
-          compiler_base: nvidia
-          compiler_module: nvidia
-          accel_module: craype-accel-nvidia60
+        - config_name: nvidia-gpu-acc
+          rte-kernels: openacc
+          compiler_modules: "PrgEnv-nvidia nvidia craype-accel-nvidia60 cdt-cuda/21.09 !cray-libsci_acc"
           # Generic accelerator flag
-          FCFLAGS: "-O3 -acc -Mallocatable=03 -gopt"
-          RTE_KERNELS: openacc
+          fcflags: "-O3 -acc -Mallocatable=03 -gopt"
         - config_name: cce-cpu-icon-production
-          cdt_version: cdt-cuda/22.05
-          compiler_base: cray
-          compiler_module: cce
-          accel_module: ""
+          rte-kernels: default
+          compiler_modules: "PrgEnv-cray"
           # Production flags for Icon model
-          RTE_KERNELS: default
-          FCFLAGS: "-hadd_paren -r am -Ktrap=divz,ovf,inv -hflex_mp=intolerant -hfp1 -hnoacc -O1,cache0"
-        - config_name: cce-openmp
-          cdt_version: cdt-cuda/22.05
-          compiler_base: cray
-          compiler_module: cce
-          accel_module: craype-accel-nvidia60
+          fcflags: "-hadd_paren -r am -Ktrap=divz,ovf,inv -hflex_mp=intolerant -hfp1 -hnoacc -O1,cache0"
+        - config_name: cce-gpu-openmp
+          rte-kernels: openacc
+          compiler_modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05"
           # OpenMP flags from Nichols Romero (Argonne)
-          FCFLAGS: "-hnoacc -homp -O0"
-          RTE_KERNELS: openacc
+          fcflags: "-hnoacc -homp -O0"
+
     env:
-      FCFLAGS: ${{ matrix.FCFLAGS }}
-      RTE_KERNELS: ${{ matrix.RTE_KERNELS }}
+      # Core variables:
+      FC: ftn
+      FCFLAGS: ${{ matrix.fcflags }}
+      # Make variables:
+      NCHOME: /dummy
+      NFHOME: /dummy
+      RRTMGP_ROOT: ${{ github.workspace }}
+      RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD: "srun -C gpu -A d56 -p cscsci -t 15:00"
+      # Auxiliary variables:
+      MODULES: "daint-gpu ${{ matrix.compiler_modules }} cray-netcdf cray-hdf5"
     steps:
-    - name: Check out code
-      uses: actions/checkout@v3
-    - name: Create module environment
+    #
+    # Checks-out repository under $GITHUB_WORKSPACE
+    #
+    - uses: actions/checkout@v3
+    #
+    # Finalize build environment
+    #
+    - name: Finalize build environment
       run: |
-        set -e
-        echo '
-        module load daint-gpu
-        module load ${{ matrix.cdt_version }}
-        export PATH=$CRAY_BINUTILS_BIN:$PATH
-        module swap PrgEnv-cray PrgEnv-${{ matrix.compiler_base }}
-        module swap ${{ matrix.compiler_base }} ${{ matrix.compiler_module }}
-        module load ${{ matrix.accel_module }}
-        module load cray-netcdf cray-hdf5
-        module rm cray-libsci_acc
-        export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
-        export CUDA_HOME=$CUDATOOLKIT_HOME
-        echo Compiler Environment:
-        module list
-        echo LD_LIBRARY_PATH is:
-        echo $LD_LIBRARY_PATH
-        ' > compiler_modules
-    - name: Stage files
+        # There are significant limitations on what can go into ${GITHUB_ENV},
+        # therefore, we use ${BASH_ENV} but only when necessary:
+        BASH_ENV="${GITHUB_WORKSPACE}/.bash"
+        echo "source '${GITHUB_WORKSPACE}/.github/workflows/module_switcher'" >> "${BASH_ENV}"
+        echo "switch_for_module ${MODULES}" >> "${BASH_ENV}"
+        # Use custom Python environment:
+        #   The environment can be re-generated as follows:
+        #     module load cray-python
+        #     python3 -m venv /scratch/snx3000/rpincus/rte-rrtmgp-python
+        #     /scratch/snx3000/rpincus/rte-rrtmgp-python/bin/pip3 install --upgrade pip
+        #     /scratch/snx3000/rpincus/rte-rrtmgp-python/bin/pip3 install netCDF4 xarray dask[array]
+        echo "PATH=\"/scratch/snx3000/rpincus/rte-rrtmgp-python/bin:\${PATH}\"" >> "${BASH_ENV}"
+        # Make bash run the above on startup:
+        echo "BASH_ENV=${BASH_ENV}" >> "${GITHUB_ENV}"
+        # Compiler needs more temporary space than normally available:
+        tmpdir='${{ github.workspace }}/tmp'
+        mkdir "${tmpdir}" && echo "TMPDIR=${tmpdir}" >> "${GITHUB_ENV}"
+    #
+    # Build libraries, examples and tests
+    #
+    - name: Build libraries, examples and tests
       run: |
-        set -e
-        cd examples/rfmip-clear-sky
-        source ./stage_files.sh
-    - name: Make
-      run: |
-        set -e
-        source compiler_modules
-        export RRTMGP_ROOT=$PWD
-        export FC=ftn
-        # Compiler needs more temporary space than normally available
-        mkdir -p $PWD/tmp
-        export TMPDIR=$PWD/tmp
-        make clean
+        $FC --version
         make libs
         make -C build separate-libs
-    - name: Run
-      run: |
-        set -e
-        export TMPDIR=$PWD/tmp
-        source compiler_modules
-        module load cray-python
-        export RRTMGP_ROOT=$PWD
-        make tests
-    - name: Check results
-      run: |
-        set -e
-        module load daint-gpu
-        export RRTMGP_ROOT=$PWD
-        # This module will unload some of the build modules, so do the checks separately
-        module load netcdf4-python
-        . /scratch/snx3000/rpincus/netcdf-env/bin/activate
-        make check
+    #
+    # Run examples and tests
+    #
+    - name: Run examples and tests
+      run: make tests
+    #
+    # Compare the results
+    #
+    - name: Compare the results
+      run: make check

--- a/environment-noplots.yml
+++ b/environment-noplots.yml
@@ -1,0 +1,11 @@
+#
+# Python modules below are needed to run tests and check results
+#
+name: rte_rrtmgp_test_noplots
+
+dependencies:
+  - conda-forge::python=3.9
+  - conda-forge::netcdf4
+  - conda-forge::xarray
+  - conda-forge::dask
+  - conda-forge::numpy

--- a/environment.yml
+++ b/environment.yml
@@ -5,12 +5,6 @@ name: rte_rrtmgp_test
 
 dependencies:
   - conda-forge::python=3.9
-  - conda-forge::urllib3
   - conda-forge::netcdf4
   - conda-forge::xarray
   - conda-forge::dask
-  - conda-forge::numpy
-  - conda-forge::scipy
-  - conda-forge::matplotlib
-  - conda-forge::seaborn
-  - conda-forge::colorcet

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,16 @@
 #
-# Python modules below are needed to run tests and check results
+# Python modules below are needed to run tests, check results and generate validation plots
 #
 name: rte_rrtmgp_test
 
 dependencies:
   - conda-forge::python=3.9
+  - conda-forge::urllib3
   - conda-forge::netcdf4
   - conda-forge::xarray
   - conda-forge::dask
+  - conda-forge::numpy
+  - conda-forge::scipy
+  - conda-forge::matplotlib
+  - conda-forge::seaborn
+  - conda-forge::colorcet

--- a/examples/rfmip-clear-sky/compare-to-reference.py
+++ b/examples/rfmip-clear-sky/compare-to-reference.py
@@ -12,39 +12,24 @@ import xarray as xr
 
 tst_dir = "."
 rrtmgp_suffix = "_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc"
-
-
-def construct_esgf_remote_name(var):
-    #
-    # For a given variable name, provide the OpenDAP URL for the RTE+RRTMGP
-    # RFMIP results
-    #   This doesn't seem to work on CSCS Piz Daint within the netcdf-python
-    #   module
-    #
-    esgf_url_base = ("http://esgf3.dkrz.de/thredds/dodsC/"
-                     "cmip6/RFMIP/RTE-RRTMGP-Consortium/RTE-RRTMGP-181204/"
-                     "rad-irf/r1i1p1f1/Efx/")
-    # DKRZ server has been unstable - better to try the other if one fails
-    esgf_url_base = ("http://esgf-data1.llnl.gov/thredds/dodsC/css03_data/"
-                     "CMIP6/RFMIP/RTE-RRTMGP-Consortium/RTE-RRTMGP-181204/"
-                     "rad-irf/r1i1p1f1/Efx/")
-    esgf_url_ver = "gn/v20191007/"
-    return os.path.join(esgf_url_base, var, esgf_url_ver, var + rrtmgp_suffix)
+max_dwd_attempts = 3
 
 
 #
-# Construct URL for RTE+RRTMGP results for RFMIP from ESGF
+# Construct a list of possible URLs for RTE+RRTMGP results for RFMIP from ESGF
 #
-def construct_esgf_file(var):
-    esgf_url_base = ("http://esgf3.dkrz.de/thredds/fileServer/"
-                     "cmip6/RFMIP/RTE-RRTMGP-Consortium/RTE-RRTMGP-181204/"
-                     "rad-irf/r1i1p1f1/Efx/")
-    # DKRZ node goes down frequently
-    esgf_url_base = ("http://esgf-data1.llnl.gov/thredds/fileServer/css03_data/"
-                     "CMIP6/RFMIP/RTE-RRTMGP-Consortium/RTE-RRTMGP-181204/"
-                     "rad-irf/r1i1p1f1/Efx/")
+def construct_esgf_files(var):
+    esgf_url_bases = [
+        "http://esgf-data1.llnl.gov/thredds/fileServer/css03_data/"
+        "CMIP6/RFMIP/RTE-RRTMGP-Consortium/RTE-RRTMGP-181204/"
+        "rad-irf/r1i1p1f1/Efx/",
+        "http://esgf3.dkrz.de/thredds/fileServer/"
+        "cmip6/RFMIP/RTE-RRTMGP-Consortium/RTE-RRTMGP-181204/"
+        "rad-irf/r1i1p1f1/Efx/"
+    ]
     esgf_url_ver = "gn/v20191007/"
-    return os.path.join(esgf_url_base, var, esgf_url_ver, var + rrtmgp_suffix)
+    return [os.path.join(esgf_url_base, var, esgf_url_ver, var+rrtmgp_suffix)
+            for esgf_url_base in esgf_url_bases]
 
 
 #
@@ -75,9 +60,28 @@ if __name__ == '__main__':
         print("Downloading reference data")
         os.makedirs(args.ref_dir, exist_ok=True)
         for v in variables:
-            urllib.request.urlretrieve(construct_esgf_file(v),
-                                       os.path.join(args.ref_dir,
-                                                    v + rrtmgp_suffix))
+            filename = v + rrtmgp_suffix
+            possible_urls = construct_esgf_files(v)
+            dwd_attempt_num = 1
+            dwd_success = False
+            while dwd_attempt_num <= max_dwd_attempts:
+                print("{0} (attempt {1})".format(filename, dwd_attempt_num))
+                for url in possible_urls:
+                    print('\tfrom {0}...'.format(url[:73]))
+                    try:
+                        urllib.request.urlretrieve(url, os.path.join(args.ref_dir, filename))
+                        dwd_success = True
+                        break
+                    except:
+                        pass
+
+                if dwd_success:
+                    break
+
+                dwd_attempt_num += 1
+
+            if not dwd_success:
+                raise Exception("Failed to download {0}".format(filename))
 
     tst = xr.open_mfdataset(os.path.join(tst_dir, "r??" + rrtmgp_suffix),
                             combine='by_coords')

--- a/tests/validation-plots.py
+++ b/tests/validation-plots.py
@@ -67,9 +67,14 @@ if __name__ == '__main__':
     gp['lw_flux_up_from_deriv'] = gp.lw_flux_up + gp.lw_jaco_up
     gp.lw_flux_up_from_deriv.attrs = {
         "description": "LW flux up, surface T+1K, computed from Jacobian"}
-    lbl = xr.open_mfdataset(
-        [construct_lbl_esgf_name(v, esgf_node="dkrz") for v in ["rsd", "rsu", "rld", "rlu"]],
-        combine="by_coords").sel(expt=0)
+    try:
+        lbl = xr.open_mfdataset([construct_lbl_esgf_name(v, esgf_node="dkrz")
+                                 for v in ["rsd", "rsu", "rld", "rlu"]],
+                                combine="by_coords").sel(expt=0)
+    except:
+        lbl = xr.open_mfdataset([construct_lbl_esgf_name(v, esgf_node="llnl")
+                                 for v in ["rsd", "rsu", "rld", "rlu"]],
+                                combine="by_coords").sel(expt=0)
     ########################################################################
     #
     # The RFMIP cases are on an irregular pressure grid so we can't compute


### PR DESCRIPTION
1. Fixes caching of RFMIP files. Currently, the files are cached but not used: each job still downloads the files.
3. Installs `zstd` on top of the container images, which makes `CI` and `Containerized-CI` use the same cache (see [here](https://github.com/actions/cache#cache-version) why).
3. Introduces caching of the Conda environment. This saves ~500MB of incoming traffic per job (~4x500MB per workflow run).
4. Removes entries from `environment.yml` that are not needed to run the CI jobs. This reduces the cache file from ~500MB to ~280MB. I guess we can reduce it further if we switch to `apt-get install` and `pip install`.
5. Replaces custom installation of `HDF5`, `NetCDF-C` and `NetCDF-Fortran` in the `CI` jobs with Ubuntu package `libnetcdff-dev`, which works because Fortran module files for Gfortran 9 and Gfortran 10 are compatible.
6. Drops installation of Gfortran in `doc-deployment.yml` because it seems redundant to me but I might be wrong: I haven't thoroughly compared the results before and after the change.
7. Makes the environment module manipulations on Daint (`self-hosted-ci.yml`) easier (hopefully). The exact mechanism is used in ICON development.
8. Switches to a newly installed Python environment on Daint, which saves cumbersome environment manipulations before we can start using it.
9. Introduces general refactoring of the CI configurations: they look similar to each other as much as possible, which is supposed to make it easier to understand what we test.

Tip: it might happen at some point that the cached files (i.e. RFMIP or Conda) do not match changes in the code and the workflows will start failing because of that. Some time ago, it was not possible to update/remove the cache files. The only way to tell the jobs that they should not use the existing cache but download the files on their own was to change the `key`. Now, we can easily remove invalid/obsolete caches [here](https://github.com/earth-system-radiation/rte-rrtmgp/actions/caches).

Recommendations on the containers:
1. Intel container should source `/opt/intel/oneapi/setvars.sh` (e.g. in `~/.profile`) so that the respective CI jobs don't have to do that over and over again.
2. The containers should have `zstd` installed for the same reason.
3. ~It makes sense to reduce the size of the containers by appending `&& rm -rf /var/lib/apt/lists/*` to the last `apt-get install` command of a container.~ (the reduction in size is negligible)
4. ~It's a good general practice to create a non-root user in the container and switch to it. In my opinion, it makes sense to adopt that.~ (see https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user)