### PR TITLE
Update CI: fix caching

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -38,7 +38,7 @@ jobs:
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD:
       # Auxiliary variables:
-      RFMIP_CACHEDIR: /home/runner/rfmip-files
+      RFMIP_CACHEDIR: .testcache
     steps:
     #
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -58,8 +58,8 @@ jobs:
     - name: Stage RFMIP files
       run: |
         if test ! -d "${RFMIP_CACHEDIR}"; then
-          mkdir -p "${RFMIP_CACHEDIR}" && cd "${RFMIP_CACHEDIR}"
-          python "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/stage_files.py"
+          mkdir -p "${RFMIP_CACHEDIR}"
+          ( cd "${RFMIP_CACHEDIR}" && python "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/stage_files.py" )
         fi
         for file in "${RFMIP_CACHEDIR}"/*; do
           if test ! -d "${file}"; then

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,7 +31,7 @@ jobs:
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD:
       # Auxiliary variables:
-      RFMIP_CACHEDIR: /home/runner/rfmip-files
+      RFMIP_CACHEDIR: .testcache
     steps:
     #
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -82,8 +82,8 @@ jobs:
     - name: Stage RFMIP files
       run: |
         if test ! -d "${RFMIP_CACHEDIR}"; then
-          mkdir -p "${RFMIP_CACHEDIR}" && cd "${RFMIP_CACHEDIR}"
-          python "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/stage_files.py"
+          mkdir -p "${RFMIP_CACHEDIR}"
+          ( cd "${RFMIP_CACHEDIR}" && python "${GITHUB_WORKSPACE}/examples/rfmip-clear-sky/stage_files.py" )
         fi
         for file in "${RFMIP_CACHEDIR}"/*; do
           if test ! -d "${file}"; then


### PR DESCRIPTION
It turns out that the `path` specified for the `cache` action is what will be added to the cache tarball but, unfortunately, not necessarily what will be extracted from it. A potential inconsistency is due to the fact that files from the `path` are added to the tarball with paths relative to the current working directory (even if `path` is absolute). This means that if we extract files from the tarball while working in a directory with a different nesting level, they end up not in the `path` but somewhere else.

This is what happens when the cache tarball is created in one of our workflows and extracted in another one: the regular runners work in `/home/runner/work/rte-rrtmgp/rte-rrtmgp` and the containerized ones in `/__w/rte-rrtmgp/rte-rrtmgp`. So, the cache generated by one workflow is not really used in another one, although the `cache` action reports on a hit.

A workaround for the issue is to use the same **relative** `path` for both workflows, which is implemented in this PR.