### PR TITLE
Update CI: fix linking for 'cce-gpu-openmp'

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -33,7 +33,7 @@ jobs:
           experimental: false
         - config-name: cce-gpu-openmp
           rte-kernels: openacc
-          compiler-modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05"
+          compiler-modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05 cudatoolkit/11.2.0_3.39-2.1__gf93aa1c"
           # OpenMP flags from Nichols Romero (Argonne)
           fcflags: "-hnoacc -homp -O0"
           experimental: true
@@ -68,12 +68,15 @@ jobs:
         #     python3 -m venv /scratch/snx3000/rpincus/rte-rrtmgp-python
         #     /scratch/snx3000/rpincus/rte-rrtmgp-python/bin/pip3 install --upgrade pip
         #     /scratch/snx3000/rpincus/rte-rrtmgp-python/bin/pip3 install dask[array] netCDF4 numpy xarray
-        echo "PATH=\"/scratch/snx3000/rpincus/rte-rrtmgp-python/bin:\${PATH}\"" >> "${BASH_ENV}"
+        echo 'PATH="/scratch/snx3000/rpincus/rte-rrtmgp-python/bin:${PATH}"' >> "${BASH_ENV}"
         # Make bash run the above on startup:
         echo "BASH_ENV=${BASH_ENV}" >> "${GITHUB_ENV}"
         # Compiler needs more temporary space than normally available:
         tmpdir='${{ github.workspace }}/tmp'
         mkdir "${tmpdir}" && echo "TMPDIR=${tmpdir}" >> "${GITHUB_ENV}"
+        # We use the "non-default products" for the tests
+        # (see https://support.hpe.com/hpesc/public/docDisplay?docId=a00113984en_us&page=Modify_Linking_Behavior_to_Use_Non-default_Libraries.html):
+        echo 'LD_LIBRARY_PATH="${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}"' >> "${BASH_ENV}"
     #
     # Build libraries, examples and tests
     #

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - config-name: nvidia-gpu-acc
+        - config-name: nvidia-gpu-openacc
           rte-kernels: openacc
           compiler-modules: "PrgEnv-nvidia nvidia craype-accel-nvidia60 cdt-cuda/21.09 !cray-libsci_acc"
           # Generic accelerator flag


### PR DESCRIPTION
1. Make the names of the self-hosted configurations consistent. Once this is merged, we can update the branch protection rules. If the list of tests below looks like I expect it to, it requires configurations we don't have anymore.
2. Fix linking for the `cce-gpu-openmp`. The job now fails when running the executables due to some failed sanity checks in the library's code. However interested in OpenMP can now investigate the issue. First, I would check whether the input values are correctly read from NetCDF files.