### PR TITLE
Add testing of OpenMP GPU offload with IFX

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
+      continue-on-error: ${{ matrix.experimental }}
       matrix:
         fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, openacc]
@@ -25,22 +26,26 @@ jobs:
         # Set flags for Intel Fortran Compiler Classic
         - fortran-compiler: ifort
           offload: false
-          # TODO: do we need -m64 or not?
           fcflags: "-m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
-        # Set flags for Intel Fortran Compiler
+          experimental: false
+        # Set flags for Intel ifx Fortran Compiler
         - fortran-compiler: ifx
           offload: false
           fcflags: "-debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
+          experimental: false
         - fortran-compiler: ifx
           offload: true
           fcflags: "-fiopenmp -fopenmp-target=spir64 -debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
+          experimental: true
         # Set flags for NVIDIA Fortran compiler
         - fortran-compiler: nvfortran
           offload: false
           fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+          experimental: false
         - fortran-compiler: nvfortran
           offload: true
           fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk -acc"
+          experimental: false
         # Set container images
         - fortran-compiler: ifort
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -26,7 +26,7 @@ jobs:
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
         - config-name: ifx-openmp
           fortran-compiler: ifx
-          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
         - config-name: nvfortran
           fortran-compiler: nvfortran

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -15,23 +15,33 @@ jobs:
       matrix:
         fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, openacc]
+        offload: [true, false]
+        exclude: 
+          - offload: true
+            rte-kernels: default
+          - offload: true
+            fortran-compiler: ifort
         include:
-        - config-name: ifort 
-          fortran-compiler: ifort
-          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+        - fortran-compiler: [ifort, ifx]
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
-        - config-name: ifx-default
-          fortran-compiler: ifx
-          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
-          image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
-        - config-name: ifx-openmp
-          fortran-compiler: ifx
-          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
-          image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
-        - config-name: nvfortran
-          fortran-compiler: nvfortran
-          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        - fortran-compiler: nvfortran
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvfortran"
+        - fortran-compiler: ifort # Offload: true won't be tried 
+          fcflags: "-g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+        - fortran-compiler: ifx
+          offload: false 
+          fcflags: "-debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
+        - fortran-compiler: ifx
+          offload: true 
+          fcflags: "-fiopenmp -fopenmp-target=spir64 -debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
+        - fortran-compiler: ifort
+          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+        - fortran-compiler: nvfortran
+          offload: false 
+          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        - fortran-compiler: nvfortran
+          offload: true 
+          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk -acc"
     container:
       image: ${{ matrix.image }}
     env:
@@ -44,6 +54,8 @@ jobs:
       RRTMGP_ROOT: ${{ github.workspace }}
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD:
+      # https://github.com/earth-system-radiation/rte-rrtmgp/issues/194
+      OMP_TARGET_OFFLOAD: DISABLED  
       # Auxiliary variables:
       RFMIP_CACHEDIR: .testcache
     steps:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -16,17 +16,20 @@ jobs:
         fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, openacc]
         include:
-        - fortran-compiler: ifort
+        - config-name: ifort 
+          fortran-compiler: ifort
           fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
-        - fortran-compiler: ifx
-          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
-          image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
-        - name: ifx-openmp
+        - config-name: ifx-default
           fortran-compiler: ifx
           fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
-        - fortran-compiler: nvfortran
+        - config-name: ifx-openmp
+          fortran-compiler: ifx
+          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+          image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
+        - config-name: nvfortran
+          fortran-compiler: nvfortran
           fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvfortran"
     container:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -16,32 +16,38 @@ jobs:
         fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, openacc]
         offload: [true, false]
-        exclude: 
+        exclude:
           - offload: true
             rte-kernels: default
           - offload: true
             fortran-compiler: ifort
         include:
-        - fortran-compiler: [ifort, ifx]
+        # Set flags for Intel Fortran Compiler Classic
+        - fortran-compiler: ifort
+          offload: false
+          # TODO: do we need -m64 or not?
+          fcflags: "-m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+        # Set flags for Intel Fortran Compiler
+        - fortran-compiler: ifx
+          offload: false
+          fcflags: "-debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
+        - fortran-compiler: ifx
+          offload: true
+          fcflags: "-fiopenmp -fopenmp-target=spir64 -debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
+        # Set flags for NVIDIA Fortran compiler
+        - fortran-compiler: nvfortran
+          offload: false
+          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        - fortran-compiler: nvfortran
+          offload: true
+          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk -acc"
+        # Set container images
+        - fortran-compiler: ifort
+          image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
+        - fortran-compiler: ifx
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
         - fortran-compiler: nvfortran
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvfortran"
-        - fortran-compiler: ifort # Offload: true won't be tried 
-          fcflags: "-g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
-        - fortran-compiler: ifx
-          offload: false 
-          fcflags: "-debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
-        - fortran-compiler: ifx
-          offload: true 
-          fcflags: "-fiopenmp -fopenmp-target=spir64 -debug -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08"
-        - fortran-compiler: ifort
-          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
-        - fortran-compiler: nvfortran
-          offload: false 
-          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
-        - fortran-compiler: nvfortran
-          offload: true 
-          fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk -acc"
     container:
       image: ${{ matrix.image }}
     env:
@@ -55,7 +61,7 @@ jobs:
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD:
       # https://github.com/earth-system-radiation/rte-rrtmgp/issues/194
-      OMP_TARGET_OFFLOAD: DISABLED  
+      OMP_TARGET_OFFLOAD: DISABLED
       # Auxiliary variables:
       RFMIP_CACHEDIR: .testcache
     steps:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -22,6 +22,10 @@ jobs:
         - fortran-compiler: ifx
           fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
+        - name: ifx-openmp
+          fortran-compiler: ifx
+          fcflags: "-m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08"
+          image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort"
         - fortran-compiler: nvfortran
           fcflags: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
           image: "ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvfortran"

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   Containerized-CI:
     runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
-      continue-on-error: ${{ matrix.experimental }}
       matrix:
         fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, openacc]


### PR DESCRIPTION
Compile and run (on CPUs) accelerator offload code with `nvfortran` and `ifx` during continuous integration. Note that `ifx` is currently failing with an internal compiler error. Addresses #194 