### PR TITLE
extend workaround for Intel optimization bug to v19 compiler

### DIFF
--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -72,7 +72,7 @@ contains
       !! use lower (or upper) atmosphere tables 
     integer,     dimension(2,    ncol,nlay,nflav), intent(out) :: jeta
       !! Index for binary species interpolation 
-#if !defined(__INTEL_LLVM_COMPILER) && __INTEL_COMPILER >= 2021
+#if !defined(__INTEL_LLVM_COMPILER) && __INTEL_COMPILER >= 1910
     ! A performance-hitting workaround for the vectorization problem reported in
     ! https://github.com/earth-system-radiation/rte-rrtmgp/issues/159
     ! The known affected compilers are Intel Fortran Compiler Classic


### PR DESCRIPTION
I have run into the same problem addressed in PR#170 on NCAR's cheyenne using the intel compiler with CESM.  The compiler version is `ifort (IFORT) 19.1.1.217 20200306.` which sets the CPP macro `__INTEL_COMPILER` to `1910`, and thus doesn't satisfy the condition currently specified, `__INTEL_COMPILER >= 2021`.  Decreasing the compiler version in the conditional to `1910` allows us to run at our default optimization of `O2`.  Running the unit test suit on cheyenne confirms both the failure and that the suggested patch works for us.