### PR TITLE
Use direct surface albedo in GPU kernels 

### DIFF
--- a/rte-kernels/accel/mo_rte_solver_kernels.F90
+++ b/rte-kernels/accel/mo_rte_solver_kernels.F90
@@ -670,7 +670,7 @@ contains
     !
     !$acc        data create(   Rdif, Tdif, source_up, source_dn, source_srf)
     !$omp target data map(alloc:Rdif, Tdif, source_up, source_dn, source_srf)
-    call sw_dif_and_source(ncol, nlay, ngpt, top_at_1, mu0, sfc_alb_dif, &
+    call sw_dif_and_source(ncol, nlay, ngpt, top_at_1, mu0, sfc_alb_dir, &
                            tau, ssa, g,                                  &
                            Rdif, Tdif, source_dn, source_up, source_srf, gpt_flux_dir)
 


### PR DESCRIPTION
A one-character fix, thanks to @Brian-eaton and @sjsprecious: GPU kernels computing the surface source for RTE SW were using the diffuse surface albedo instead of the direct surface albedo (as the CPU kernels do, correctly). 

Not currently covered by a test but should be. 