### PR TITLE
Fix a typo in an OpenMP directive

### DIFF
--- a/rrtmgp-frontend/mo_aerosol_optics_rrtmgp_merra.F90
+++ b/rrtmgp-frontend/mo_aerosol_optics_rrtmgp_merra.F90
@@ -204,7 +204,7 @@ contains
     if(allocated(this%merra_aero_bin_lims)) then
       deallocate(this%merra_aero_bin_lims, this%aero_rh)
       !$acc        exit data delete(     this%merra_aero_bin_lims, this%aero_rh) 
-      !$omp target exit data map(release:this%merra_aero_bin_lims, this%aero_rh) &
+      !$omp target exit data map(release:this%merra_aero_bin_lims, this%aero_rh)
     end if
 
     ! Lookup table aerosol optics coefficients


### PR DESCRIPTION
This fixes a typo in the OpenMP directive that I mentioned in https://github.com/earth-system-radiation/rte-rrtmgp/pull/170#issuecomment-1652577997.