### PR TITLE
Workaround self-hosted CI

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -16,17 +16,17 @@ jobs:
       matrix:
         fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, accel]
-        fpmodel:     [DP, SP]
+        fpmodel: [DP, SP]
         include:
+        # The tests are not experimental by default:
+        - experimental: false
         # Set flags for Intel Fortran Compiler Classic
         - fortran-compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-          experimental: false
-        # Set flags for Intel ifx Fortran Compiler
+        # Set flags for Intel Fortran Compiler
         - fortran-compiler: ifx
           rte-kernels: default
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          experimental: false
         - fortran-compiler: ifx
           rte-kernels: accel
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08 -fiopenmp -fopenmp-targets=spir64
@@ -35,11 +35,9 @@ jobs:
         - fortran-compiler: nvfortran
           rte-kernels: default
           fcflags: -Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk
-          experimental: false
         - fortran-compiler: nvfortran
           rte-kernels: accel
           fcflags: -Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk -acc
-          experimental: false
         # Set container images
         - fortran-compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort
@@ -69,7 +67,7 @@ jobs:
     #
     - uses: actions/checkout@v4
     #
-    # Check out data 
+    # Check out data
     #
     - name: Check out data
       uses: actions/checkout@v4
@@ -91,8 +89,8 @@ jobs:
     - name: Run examples and tests
       run: make tests
     #
-    # Relax failure thresholds for single precision 
-    #  
+    # Relax failure thresholds for single precision
+    #
     - name: Relax failure threshold for single precision
       if: matrix.fpmodel == 'SP'
       run: echo "FAILURE_THRESHOLD=3.5e-1" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
-        fpmodel:     [DP, SP]
+        fpmodel: [DP, SP]
     env:
       # Core variables:
       FC: ${{ matrix.fortran-compiler }}
@@ -32,8 +32,8 @@ jobs:
       FAILURE_THRESHOLD: 7.e-4
     steps:
     #
-    # Relax failure thresholds for single precision 
-    #  
+    # Relax failure thresholds for single precision
+    #
     - name: Relax failure threshold for single precision
       if: matrix.fpmodel == 'SP'
       run: echo "FAILURE_THRESHOLD=3.5e-1" >> $GITHUB_ENV
@@ -43,7 +43,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     #
-    # Check out data 
+    # Check out data
     #
     - name: Check out data
       uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
         repository: earth-system-radiation/rrtmgp-data
         path: rrtmgp-data
         ref: develop
-    #    
+    #
     # Synchronize the package index
     #
     - name: Synchronize the package index

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -13,27 +13,27 @@ defaults:
 
 jobs:
   CI:
-    runs-on: 
-      labels: cscs-ci 
+    runs-on:
+      labels: cscs-ci
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        config-name: [nvidia-gpu-openacc, cce-cpu-icon-production, cce-gpu-openmp] 
-        fpmodel:     [DP, SP]
+        config-name: [nvidia-gpu-openacc, cce-cpu-icon-production, cce-gpu-openmp]
+        fpmodel: [DP, SP]
         include:
+        # The tests are not experimental by default:
+        - experimental: false
         - config-name: nvidia-gpu-openacc
           rte-kernels: accel
           compiler-modules: "PrgEnv-nvidia nvidia craype-accel-nvidia60 cdt-cuda/21.09 !cray-libsci_acc"
           # Generic accelerator flag
           fcflags: "-O3 -acc -Mallocatable=03 -gopt"
-          experimental: false
         - config-name: cce-cpu-icon-production
           rte-kernels: default
           compiler-modules: "PrgEnv-cray"
           # Production flags for Icon model
           fcflags: "-hadd_paren -r am -Ktrap=divz,ovf,inv -hflex_mp=intolerant -hfp1 -hnoacc -O1,cache0"
-          experimental: false
         - config-name: cce-gpu-openmp
           rte-kernels: accel
           compiler-modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05 cudatoolkit/11.2.0_3.39-2.1__gf93aa1c"
@@ -56,7 +56,7 @@ jobs:
     #
     - uses: actions/checkout@v3
     #
-    # Check out data 
+    # Check out data
     #
     - name: Check out data
       uses: actions/checkout@v3
@@ -106,8 +106,8 @@ jobs:
     - name: Run examples and tests
       run: make tests
     #
-    # Relax failure thresholds for single precision 
-    #  
+    # Relax failure thresholds for single precision
+    #
     - name: Relax failure threshold for single precision
       if: matrix.fpmodel == 'SP'
       run: echo "FAILURE_THRESHOLD=3.5e-1" >> $GITHUB_ENV

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -54,12 +54,12 @@ jobs:
     #
     # Checks-out repository under $GITHUB_WORKSPACE
     #
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     #
     # Check out data 
     #
     - name: Check out data
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         repository: earth-system-radiation/rrtmgp-data
         path: rrtmgp-data


### PR DESCRIPTION
Somehow, #227 broke the self-hosted CI. It now fails with:
```console
/users/rpincus/actions-runner-101/externals/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /users/rpincus/actions-runner-101/externals/node20/bin/node)
/users/rpincus/actions-runner-101/externals/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /users/rpincus/actions-runner-101/externals/node20/bin/node)
```

I can't (and don't know yet how to) fix the issue on the server side, so I tried to downgrade `actions/checkout` back to version 3 in `self-hosted-ci.yml` and it worked. Maybe we should have the workaround in the `develop` for the time being.

I also took the liberty to clean up the CI configuration files a bit.