### PR TITLE
Fix argument parsing in rfmip-clear-sky drivers

### DIFF
--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
@@ -121,6 +121,7 @@ program rrtmgp_rfmip_lw
   !
   print *, "Usage: rrtmgp_rfmip_lw [block_size] [rfmip_file] [k-distribution_file] [forcing_index (1,2,3)] [physics_index (1,2)]"
   nargs = command_argument_count()
+  if(nargs >= 2) call get_command_argument(2, rfmip_file)
   call read_size(rfmip_file, ncol, nlay, nexp)
   if(nargs >= 1) then
     call get_command_argument(1, block_size_char)
@@ -128,7 +129,6 @@ program rrtmgp_rfmip_lw
   else
     block_size = ncol
   end if
-  if(nargs >= 2) call get_command_argument(2, rfmip_file)
   if(nargs >= 3) call get_command_argument(3, kdist_file)
   if(nargs >= 4) call get_command_argument(4, forcing_index_char)
   if(nargs >= 5) call get_command_argument(5, physics_index_char)

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
@@ -86,8 +86,8 @@ program rrtmgp_rfmip_lw
   !
   ! Local variables
   !
-  character(len=132) :: rfmip_file = 'multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc', &
-                        kdist_file = 'coefficients_lw.nc'
+  character(len=256) :: rfmip_file = 'multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc'
+  character(len=132) :: kdist_file = 'coefficients_lw.nc'
   character(len=132) :: flxdn_file, flxup_file
   integer            :: nargs, ncol, nlay, nbnd, nexp, nblocks, block_size, forcing_index, physics_index, n_quad_angles = 1
   logical            :: top_at_1

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -86,8 +86,8 @@ program rrtmgp_rfmip_sw
   !
   ! Local variables
   !
-  character(len=132) :: rfmip_file = 'multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc', &
-                        kdist_file = 'coefficients_sw.nc'
+  character(len=256) :: rfmip_file = 'multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc'
+  character(len=132) :: kdist_file = 'coefficients_sw.nc'
   character(len=132) :: flxdn_file, flxup_file
   integer            :: nargs, ncol, nlay, nbnd, ngpt, nexp, nblocks, block_size, forcing_index
   logical            :: top_at_1

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -124,6 +124,7 @@ program rrtmgp_rfmip_sw
   !
   print *, "Usage: rrtmgp_rfmip_sw [block_size] [rfmip_file] [k-distribution_file] [forcing_index (1,2,3)]"
   nargs = command_argument_count()
+  if(nargs >= 2) call get_command_argument(2, rfmip_file)
   call read_size(rfmip_file, ncol, nlay, nexp)
   if(nargs >= 1) then
     call get_command_argument(1, block_size_char)
@@ -131,7 +132,6 @@ program rrtmgp_rfmip_sw
   else
     block_size = ncol
   end if
-  if(nargs >= 2) call get_command_argument(2, rfmip_file)
   if(nargs >= 3) call get_command_argument(3, kdist_file)
   if(nargs >= 4) then
     call get_command_argument(4, forcing_index_char)


### PR DESCRIPTION
I think there is a bug in `rrtmgp_rfmip_sw.F90` and `rrtmgp_rfmip_lw.F90`: the `rfmip_file` variable is used before it is updated with the argument from the command line. This is my attempt to fix the problem. I would also like to specify `rfmip_file` on the command line in the `autoconf` branch and 132 characters is not enough for that given the long basename of the file. Therefore, I set the maximum length of the variable to 256.

Ideally, of course, we wouldn't have to have the limit at all since even 256 might not be enough in certain scenarios.