### PR TITLE
Private implicit

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       # Core variables:
       FC: ${{ matrix.fortran-compiler }}
-      FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DRTE_USE_CBOOL -DRTE_USE_${{ matrix.fpmodel }}"
+      FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -fmodule-private -fimplicit-none -finit-real=nan -g -DRTE_USE_CBOOL -DRTE_USE_${{ matrix.fpmodel }}"
       # Make variables:
       NFHOME: /usr
       RRTMGP_ROOT: ${{ github.workspace }}

--- a/rte-kernels/mo_rte_util_array.F90
+++ b/rte-kernels/mo_rte_util_array.F90
@@ -20,6 +20,7 @@ module mo_rte_util_array
   interface zero_array
     module procedure zero_array_1D, zero_array_2D, zero_array_3D, zero_array_4D
   end interface
+  public :: zero_array
 contains
  !-------------------------------------------------------------------------------------------------
   ! Initializing arrays to 0


### PR DESCRIPTION
This adds a missing `public` statement. I also took the liberty to extend the `FCFLAGS` for `gfortran` in the CI jobs with `-fmodule-private -fimplicit-none` to prevent this kind of minor inaccuracies.