### PR TITLE
Fix minmaxloc workaround

### DIFF
--- a/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
@@ -252,7 +252,7 @@ contains
       !$omp target teams distribute parallel do simd
       do icol = 1,ncol
         itropo_lower(icol,2) = nlay
-#if ( defined(_CRAYFTN) && defined(_OPENMP) ) || defined(__NVCOMPILER)
+#if ( defined(_CRAYFTN) && _RELEASE_MAJOR <= 14 ) || ( defined(_OPENMP) && defined(__NVCOMPILER) )
         itropo_upper(icol,1) = 1
         call minmaxloc(icol, tropo, play, itropo_lower(icol,1), itropo_upper(icol,2))
 #else
@@ -266,7 +266,7 @@ contains
       !$omp target teams distribute parallel do simd
       do icol = 1,ncol
         itropo_lower(icol,1) = 1
-#if ( defined(_CRAYFTN) && defined(_OPENMP) ) || defined(__NVCOMPILER)
+#if ( defined(_CRAYFTN) && _RELEASE_MAJOR <= 14 ) || ( defined(_OPENMP) && defined(__NVCOMPILER) )
         itropo_upper(icol,2) = nlay
         call minmaxloc(icol, tropo, play, itropo_lower(icol,2), itropo_upper(icol,1))
 #else


### PR DESCRIPTION
This fixes the condition for the `minmaxloc` workaround:
1. Cray compiler supports `minloc` and `maxloc` for OpenACC and OpenMP starting version 15.
2. Nvidia compiler supports `minloc` and `maxloc` for OpenACC but not for OpenMP (see #113).