### PR TITLE
Simplify build flags

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
       FC: ${{ matrix.fortran-compiler }}
       FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -fmodule-private -fimplicit-none -finit-real=nan -g -DRTE_USE_CBOOL -DRTE_USE_${{ matrix.fpmodel }}"
       # Make variables:
-      NFHOME: /usr
+      FCINCLUDE: -I/usr/include
       RRTMGP_ROOT: ${{ github.workspace }}
       RRTMGP_DATA: ${{ github.workspace }}/rrtmgp-data
       RUN_CMD:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -22,4 +22,4 @@ variables:
   FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -g -DRTE_USE_CBOOL"
   # Shell environment variables can't be used within this YML files, so
   # Users still need to set RRTMGP_ROOT,
-  #  NCHOME = CONDA_PREFIX, NFHOME = CONDA_PREFIX
+  #  FCINCLUDE=-I${CONDA_PREFIX}/include

--- a/examples/all-sky/Makefile
+++ b/examples/all-sky/Makefile
@@ -9,12 +9,11 @@ LDFLAGS   += -L$(RRTMGP_BUILD)
 LIBS      += -lrrtmgp -lrte
 FCINCLUDE += -I$(RRTMGP_BUILD)
 
-#
-# netcdf library, module files
-# Environment variables NCHOME and NFHOME point to root of C and Fortran interfaces respectively -
-#
-FCINCLUDE += -I$(NFHOME)/include
-LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
+# netcdf Fortran module files has to be in the search path or added via environment variable FCINCLUDE e.g. 
+#FCINCLUDE += -I$(NFHOME)/include
+
+# netcdf C and Fortran libraries have to be in the search path or added via environment variable LDFLAGS e.g. 
+#LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf
 
 VPATH = ../:$(RRTMGP_ROOT)/rrtmgp-frontend # Needed for cloud_optics and aerosol_optics

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -10,11 +10,11 @@ RRTMGP_BUILD = $(RRTMGP_ROOT)/build
 FCINCLUDE += -I$(RRTMGP_BUILD)
 
 #
-# netcdf library, module files
-# Environment variables NCHOME and NFHOME point to root of C and Fortran interfaces respectively -
-#
-FCINCLUDE += -I$(NFHOME)/include
-LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
+# netcdf Fortran module files has to be in the search path or added via environment variable FCINCLUDE e.g. 
+#FCINCLUDE += -I$(NFHOME)/include
+
+# netcdf C and Fortran libraries have to be in the search path or added via environment variable LDFLAGS e.g. 
+#LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf
 
 VPATH = ../

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,13 +9,13 @@ RRTMGP_BUILD = $(RRTMGP_ROOT)/build
 # LIBS      += -lrrtmgp -lrte
 FCINCLUDE += -I$(RRTMGP_BUILD)
 #
-# netcdf library, module files
-# Environment variables NCHOME and NFHOME point to root of C and Fortran interfaces respectively -
-#
-FCINCLUDE += -I$(NFHOME)/include
+# netcdf Fortran module files has to be in the search path or added via environment variable FCINCLUDE e.g. 
+#FCINCLUDE += -I$(NFHOME)/include
+
+# netcdf C and Fortran libraries have to be in the search path or added via environment variable LDFLAGS e.g. 
+#LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LDFLAGS   += -L$(RRTMGP_BUILD)
 LIBS      += -lrte -lrrtmgp
-LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf
 
 VPATH  = .:$(RRTMGP_ROOT)/examples:$(RRTMGP_ROOT)/examples/rfmip-clear-sky:$(RRTMGP_ROOT)/examples/all-sky


### PR DESCRIPTION
Getting rid of `NCHOME` and `NFHOME`