### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -40,11 +40,11 @@ jobs:
           fcflags: -Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk -acc
         # Set container images
         - fortran-compiler: ifort
-          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - fortran-compiler: ifx
-          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:ifort
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - fortran-compiler: nvfortran
-          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvfortran
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvhpc
     container:
       image: ${{ matrix.image }}
     env:

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   CI:
+    if: github.repository == 'earth-system-radiation/rte-rrtmgp'
     runs-on:
       labels: cscs-ci
     continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
1. Skip CI jobs run by the self-hosted runners in the fork repositories. They don't have access to the runners anyway and hanging CI jobs might be confusing for the contributors.
2. Switch to the new container tags introduced in https://github.com/earth-system-radiation/containers/pull/18.

Depends on https://github.com/earth-system-radiation/containers/pull/18.