### PR TITLE
Simplify LW source functions

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -59,7 +59,7 @@ jobs:
       RUN_CMD:
       # https://github.com/earth-system-radiation/rte-rrtmgp/issues/194
       OMP_TARGET_OFFLOAD: DISABLED
-      FAILURE_THRESHOLD: 7.e-4
+      FAILURE_THRESHOLD: 5.8e-2 # 7.e-4
 
     steps:
     #

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
       RRTMGP_ROOT: ${{ github.workspace }}
       RRTMGP_DATA: ${{ github.workspace }}/rrtmgp-data
       RUN_CMD:
-      FAILURE_THRESHOLD: 7.e-4
+      FAILURE_THRESHOLD: 5.8e-2 # 7.e-4
     steps:
     #
     # Relax failure thresholds for single precision

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -50,7 +50,7 @@ jobs:
       RRTMGP_DATA: ${{ github.workspace }}/rrtmgp-data
       RTE_KERNELS: ${{ matrix.rte-kernels }}
       RUN_CMD: "srun -C gpu -A d56 -p cscsci -t 15:00"
-      FAILURE_THRESHOLD: 7.e-4
+      FAILURE_THRESHOLD: 5.8e-2 # 7.e-4
     steps:
     #
     # Checks-out repository under $GITHUB_WORKSPACE

--- a/examples/all-sky/rrtmgp_allsky.F90
+++ b/examples/all-sky/rrtmgp_allsky.F90
@@ -310,10 +310,10 @@ program rte_rrtmgp_allsky
       !
       ! Should we allocate these once, rather than once per loop? They're big. 
       ! 
-      !$acc        data create(   lw_sources, lw_sources%lay_source,     lw_sources%lev_source_inc) &
-      !$acc             create(               lw_sources%lev_source_dec, lw_sources%sfc_source,     lw_sources%sfc_source_Jac)
-      !$omp target data map(alloc:            lw_sources%lay_source,     lw_sources%lev_source_inc) &
-      !$omp             map(alloc:            lw_sources%lev_source_dec, lw_sources%sfc_source,     lw_sources%sfc_source_Jac)
+      !$acc        data create(   lw_sources, lw_sources%lay_source,     lw_sources%lev_source) &
+      !$acc             create(               lw_sources%sfc_source,     lw_sources%sfc_source_Jac)
+      !$omp target data map(alloc:            lw_sources%lay_source,     lw_sources%lev_source) &
+      !$omp             map(alloc:            lw_sources%sfc_source,     lw_sources%sfc_source_Jac)
       call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
                                          t_lay, t_sfc, &
                                          gas_concs,    &

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
@@ -219,8 +219,8 @@ program rrtmgp_rfmip_lw
   !$omp target enter data map(alloc:sfc_emis_spec)
   !$acc enter data create(optical_props, optical_props%tau)
   !$omp target enter data map(alloc:optical_props%tau)
-  !$acc enter data create(source, source%lay_source, source%lev_source_inc, source%lev_source_dec, source%sfc_source)
-  !$omp target enter data map(alloc:source%lay_source, source%lev_source_inc, source%lev_source_dec, source%sfc_source)
+  !$acc enter        data create(source, source%lay_source, source%lev_source, source%sfc_source)
+  !$omp target enter data map(alloc:source%lay_source, source%lev_source, source%sfc_source)
   ! --------------------------------------------------
   !
   ! Loop over blocks
@@ -265,8 +265,8 @@ program rrtmgp_rfmip_lw
   !$omp target exit data map(release:sfc_emis_spec)
   !$acc exit data delete(optical_props%tau, optical_props)
   !$omp target exit data map(release:optical_props%tau)
-  !$acc exit data delete(source%lay_source, source%lev_source_inc, source%lev_source_dec, source%sfc_source)
-  !$omp target exit data map(release:source%lay_source, source%lev_source_inc, source%lev_source_dec, source%sfc_source)
+  !$acc exit data delete(source%lay_source, source%lev_source, source%sfc_source)
+  !$omp target exit data map(release:source%lay_source, source%lev_source, source%sfc_source)
   !$acc exit data delete(source)
   ! --------------------------------------------------m
   call unblock_and_write(trim(flxup_file), 'rlu', flux_up)

--- a/rrtmgp-frontend/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp-frontend/mo_gas_optics_rrtmgp.F90
@@ -890,9 +890,9 @@ contains
     !-------------------------------------------------------------------
     ! Compute internal (Planck) source functions at layers and levels,
     !  which depend on mapping from spectral space that creates k-distribution.
-    !$acc        data copyin(sources) copyout( sources%lay_source, sources%lev_source_inc, sources%lev_source_dec) &
+    !$acc        data copyin(sources) copyout( sources%lay_source, sources%lev_source) &
     !$acc                             copyout( sources%sfc_source, sources%sfc_source_Jac)
-    !$omp target data                 map(from:sources%lay_source, sources%lev_source_inc, sources%lev_source_dec) &
+    !$omp target data                 map(from:sources%lay_source, sources%lev_source) &
     !$omp                             map(from:sources%sfc_source, sources%sfc_source_Jac)
 
     !$acc kernels copyout(top_at_1)
@@ -907,7 +907,7 @@ contains
                 fmajor, jeta, tropo, jtemp, jpress,                    &
                 this%get_gpoint_bands(), this%get_band_lims_gpoint(), this%planck_frac, this%temp_ref_min,&
                 this%totplnk_delta, this%totplnk, this%gpoint_flavor,  &
-                sources%sfc_source, sources%lay_source, sources%lev_source_inc, sources%lev_source_dec, &
+                sources%sfc_source, sources%lay_source, sources%lev_source, &
                 sources%sfc_source_Jac)
     !$acc end        data
     !$omp end target data

--- a/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
@@ -573,7 +573,7 @@ contains
                     fmajor, jeta, tropo, jtemp, jpress,    &
                     gpoint_bands, band_lims_gpt,           &
                     pfracin, temp_ref_min, totplnk_delta, totplnk, gpoint_flavor, &
-                    sfc_src, lay_src, lev_src_inc, lev_src_dec, sfc_source_Jac) bind(C, name="rrtmgp_compute_Planck_source")
+                    sfc_src, lay_src, lev_src, sfc_source_Jac) bind(C, name="rrtmgp_compute_Planck_source")
     integer,                                    intent(in) :: ncol, nlay, nbnd, ngpt
     integer,                                    intent(in) :: nflav, neta, npres, ntemp, nPlanckTemp
     real(wp),    dimension(ncol,nlay  ),        intent(in) :: tlay
@@ -593,10 +593,10 @@ contains
     real(wp), dimension(nPlanckTemp,nbnd),        intent(in) :: totplnk
     integer,  dimension(2,ngpt),                  intent(in) :: gpoint_flavor
 
-    real(wp), dimension(ncol,     ngpt), intent(out) :: sfc_src
-    real(wp), dimension(ncol,nlay,ngpt), intent(out) :: lay_src
-    real(wp), dimension(ncol,nlay,ngpt), intent(out) :: lev_src_inc, lev_src_dec
-    real(wp), dimension(ncol,     ngpt), intent(out) :: sfc_source_Jac
+    real(wp), dimension(ncol,       ngpt), intent(out) :: sfc_src
+    real(wp), dimension(ncol,nlay,  ngpt), intent(out) :: lay_src
+    real(wp), dimension(ncol,nlay+1,ngpt), intent(out) :: lev_src
+    real(wp), dimension(ncol,       ngpt), intent(out) :: sfc_source_Jac
     ! -----------------
     ! local
     real(wp), parameter                             :: delta_Tsurf = 1.0_wp
@@ -604,7 +604,7 @@ contains
     integer  :: ilay, icol, igpt, ibnd, itropo, iflav
     integer  :: gptS, gptE
     real(wp), dimension(2), parameter :: one = [1._wp, 1._wp]
-    real(wp) :: pfrac
+    real(wp) :: pfrac, pfrac_m1 ! Planck fraction in this layer and the one below 
     real(wp) :: planck_function_1, planck_function_2
     ! -----------------
 
@@ -625,19 +625,28 @@ contains
           ! itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
           itropo = merge(1,2,tropo(icol,ilay))  !WS moved itropo inside loop for GPU
           iflav = gpoint_flavor(itropo, igpt) !eta interpolation depends on band's flavor
+          ! interpolation in temperature, pressure, and eta
           pfrac = &
-            ! interpolation in temperature, pressure, and eta
             interpolate3D(one, fmajor(:,:,:,icol,ilay,iflav), pfracin, &
                           igpt, jeta(:,icol,ilay,iflav), jtemp(icol,ilay),jpress(icol,ilay)+itropo)
+
           ! Compute layer source irradiance for g-point, equals band irradiance x fraction for g-point
           planck_function_1 = interpolate1D(tlay(icol,ilay), temp_ref_min, totplnk_delta, totplnk(:,ibnd))
-          lay_src(icol,ilay,igpt) = pfrac * planck_function_1
-          ! Compute layer source irradiance for g-point, equals band irradiance x fraction for g-point
-          planck_function_1 = interpolate1D(tlev(icol,ilay),   temp_ref_min, totplnk_delta, totplnk(:,ibnd))
-          planck_function_2 = interpolate1D(tlev(icol,ilay+1), temp_ref_min, totplnk_delta, totplnk(:,ibnd))
-          lev_src_dec(icol,ilay,igpt) = pfrac * planck_function_1
-          lev_src_inc(icol,ilay,igpt) = pfrac * planck_function_2
+          lay_src  (icol,ilay,igpt) = pfrac * planck_function_1
 
+          ! Compute layer source irradiance for g-point, equals band irradiance x fraction for g-point
+          planck_function_1 = interpolate1D(tlev(icol,ilay), temp_ref_min, totplnk_delta, totplnk(:,ibnd))
+          if (ilay == 1) then 
+            lev_src(icol,ilay,  igpt) = pfrac * planck_function_1
+          else if (ilay == nlay) then 
+            planck_function_1 = interpolate1D(tlev(icol,nlay+1), temp_ref_min, totplnk_delta, totplnk(:,ibnd))
+            lev_src(icol,nlay+1,igpt) = pfrac * planck_function_1
+          else
+            pfrac_m1 = &
+              interpolate3D(one, fmajor(:,:,:,icol,ilay-1,iflav), pfracin, &
+                            igpt, jeta(:,icol,ilay-1,iflav), jtemp(icol,ilay-1),jpress(icol,ilay-1)+itropo)
+            lev_src(icol,ilay,  igpt) = sqrt(pfrac * pfrac_m1) * planck_function_1
+          end if 
           if (ilay == sfc_lay) then
             planck_function_1 = interpolate1D(tsfc(icol)              , temp_ref_min, totplnk_delta, totplnk(:,ibnd))
             planck_function_2 = interpolate1D(tsfc(icol) + delta_Tsurf, temp_ref_min, totplnk_delta, totplnk(:,ibnd))
@@ -645,10 +654,8 @@ contains
             sfc_source_Jac(icol,igpt) = pfrac * (planck_function_2 - planck_function_1)
           end if
         end do ! igpt
-
       end do ! icol
     end do ! ilay
-
     !$acc end        data
     !$omp end target data
   end subroutine compute_Planck_source

--- a/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
@@ -639,8 +639,9 @@ contains
           if (ilay == 1) then 
             lev_src(icol,ilay,  igpt) = pfrac * planck_function_1
           else if (ilay == nlay) then 
-            planck_function_1 = interpolate1D(tlev(icol,nlay+1), temp_ref_min, totplnk_delta, totplnk(:,ibnd))
-            lev_src(icol,nlay+1,igpt) = pfrac * planck_function_1
+            lev_src(icol,ilay,  igpt) = pfrac * planck_function_1
+            planck_function_2 = interpolate1D(tlev(icol,nlay+1), temp_ref_min, totplnk_delta, totplnk(:,ibnd))
+            lev_src(icol,nlay+1,igpt) = pfrac * planck_function_2
           else
             pfrac_m1 = &
               interpolate3D(one, fmajor(:,:,:,icol,ilay-1,iflav), pfracin, &

--- a/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/accel/mo_gas_optics_rrtmgp_kernels.F90
@@ -609,9 +609,9 @@ contains
     ! -----------------
 
     !$acc        data copyin(   tlay,tlev,tsfc,fmajor,jeta,tropo,jtemp,jpress,gpoint_bands,pfracin,totplnk,gpoint_flavor) &
-    !$acc             copyout(  sfc_src,lay_src,lev_src_inc,lev_src_dec,sfc_source_Jac)
+    !$acc             copyout(  sfc_src,lay_src,lev_src,sfc_source_Jac)
     !$omp target data map(   to:tlay,tlev,tsfc,fmajor,jeta,tropo,jtemp,jpress,gpoint_bands,pfracin,totplnk,gpoint_flavor) &
-    !$omp             map(from: sfc_src,lay_src,lev_src_inc,lev_src_dec,sfc_source_Jac)
+    !$omp             map(from: sfc_src,lay_src,lev_src,sfc_source_Jac)
 
     ! Calculation of fraction of band's Planck irradiance associated with each g-point
     !$acc parallel loop tile(128,2)

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -676,7 +676,7 @@ contains
 
     ! compute level source irradiances for each g-point
     do icol = 1, ncol
-      planck_function(icol,       1,1:nbnd) = interpolate1D(tlev(icol,     1),temp_ref_min, totplnk_delta, totplnk)
+      planck_function  (icol,     1,1:nbnd) = interpolate1D(tlev(icol,     1),temp_ref_min, totplnk_delta, totplnk)
     end do
     do ilay = 1, nlay
       do icol = 1, ncol
@@ -692,13 +692,13 @@ contains
       gptE = band_lims_gpt(2, ibnd)
       do igpt = gptS, gptE
         do icol = 1, ncol
-          lev_src(icol,     1,igpt) = pfrac(icol,   1,igpt) * planck_function(icol,1,ibnd)
+          lev_src(icol,     1,igpt) = pfrac(icol,   1,igpt) * planck_function(icol,     1,ibnd)
         end do
         do ilay = 2, nlay
           do icol = 1, ncol
             lev_src(icol,ilay,igpt) = sqrt(pfrac(icol,ilay-1, igpt) *  & 
                                            pfrac(icol,ilay,   igpt)) & 
-                                                            * planck_function(icol,ilay+1,ibnd)
+                                                            * planck_function(icol,ilay,  ibnd)
           end do
         end do
         do icol = 1, ncol

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -571,7 +571,7 @@ contains
                     fmajor, jeta, tropo, jtemp, jpress,    &
                     gpoint_bands, band_lims_gpt,           &
                     pfracin, temp_ref_min, totplnk_delta, totplnk, gpoint_flavor, &
-                    sfc_src, lay_src, lev_src_inc, lev_src_dec, sfc_source_Jac) bind(C, name="rrtmgp_compute_Planck_source")
+                    sfc_src, lay_src, lev_src, sfc_source_Jac) bind(C, name="rrtmgp_compute_Planck_source")
     integer,                                    intent(in) :: ncol, nlay, nbnd, ngpt
       !! input dimensions 
     integer,                                    intent(in) :: nflav, neta, npres, ntemp, nPlanckTemp
@@ -597,11 +597,10 @@ contains
     real(wp), dimension(nPlanckTemp,nbnd),        intent(in) :: totplnk       !! Total Planck function by band at each temperature 
     integer,  dimension(2,ngpt),                  intent(in) :: gpoint_flavor !! major gas flavor (pair) by upper/lower, g-point
 
-    real(wp), dimension(ncol,     ngpt), intent(out) :: sfc_src  !! Planck emssion from the surface 
-    real(wp), dimension(ncol,nlay,ngpt), intent(out) :: lay_src  !! Planck emssion from layer centers
-    real(wp), dimension(ncol,nlay,ngpt), intent(out) :: lev_src_inc, lev_src_dec
-      !! Planck emission at layer boundaries, using spectral mapping in the direction of propagation 
-    real(wp), dimension(ncol,     ngpt), intent(out) :: sfc_source_Jac 
+    real(wp), dimension(ncol,       ngpt), intent(out) :: sfc_src  !! Planck emission from the surface 
+    real(wp), dimension(ncol,nlay,  ngpt), intent(out) :: lay_src  !! Planck emission from layer centers
+    real(wp), dimension(ncol,nlay+1,ngpt), intent(out) :: lev_src  !! Planck emission from layer boundaries
+    real(wp), dimension(ncol,       ngpt), intent(out) :: sfc_source_Jac 
       !! Jacobian (derivative) of the surface Planck source with respect to surface temperature 
     ! -----------------
     ! local
@@ -675,11 +674,13 @@ contains
       end do
     end do
 
-    ! compute level source irradiances for each g-point, one each for upward and downward paths
+    ! compute level source irradiances for each g-point
+    do icol = 1, ncol
+      planck_function(icol,       1,1:nbnd) = interpolate1D(tlev(icol,     1),temp_ref_min, totplnk_delta, totplnk)
+    end do
     do ilay = 1, nlay
       do icol = 1, ncol
-      planck_function(icol,     1,1:nbnd) = interpolate1D(tlev(icol,     1),temp_ref_min, totplnk_delta, totplnk)
-      planck_function(icol,ilay+1,1:nbnd) = interpolate1D(tlev(icol,ilay+1),temp_ref_min, totplnk_delta, totplnk)
+        planck_function(icol,ilay+1,1:nbnd) = interpolate1D(tlev(icol,ilay+1),temp_ref_min, totplnk_delta, totplnk)
       end do
     end do
 
@@ -690,11 +691,18 @@ contains
       gptS = band_lims_gpt(1, ibnd)
       gptE = band_lims_gpt(2, ibnd)
       do igpt = gptS, gptE
-        do ilay = 1, nlay
+        do icol = 1, ncol
+          lev_src(icol,     1,igpt) = pfrac(icol,   1,igpt) * planck_function(icol,1,ibnd)
+        end do
+        do ilay = 2, nlay
           do icol = 1, ncol
-            lev_src_inc(icol,ilay,igpt) = pfrac(icol,ilay,igpt) *planck_function(icol,ilay+1,ibnd)
-            lev_src_dec(icol,ilay,igpt) = pfrac(icol,ilay,igpt) *planck_function(icol,ilay  ,ibnd)
+            lev_src(icol,ilay,igpt) = sqrt(pfrac(icol,ilay-1, igpt) *  & 
+                                           pfrac(icol,ilay,   igpt)) & 
+                                                            * planck_function(icol,ilay+1,ibnd)
           end do
+        end do
+        do icol = 1, ncol
+          lev_src(icol,nlay+1,igpt) = pfrac(icol,nlay,igpt) * planck_function(icol,nlay+1,ibnd)
         end do
       end do
     end do

--- a/rte-frontend/mo_rte_lw.F90
+++ b/rte-frontend/mo_rte_lw.F90
@@ -353,8 +353,8 @@ contains
                                 logical(top_at_1, wl), n_quad_angs,         &
                                 secants, gauss_wts(1:n_quad_angs,n_quad_angs), &
                                 optical_props%tau,                 &
-                                sources%lay_source, sources%lev_source_inc, &
-                                sources%lev_source_dec,            &
+                                sources%lay_source,                &
+                                sources%lev_source,                &
                                 sfc_emis_gpt, sources%sfc_source,  &
                                 inc_flux_diffuse,                  &
                                 gpt_flux_up, gpt_flux_dn,          &
@@ -371,8 +371,8 @@ contains
             ! two-stream calculation with scattering
             !
             call lw_solver_2stream(ncol, nlay, ngpt, logical(top_at_1, wl), &
-                                   optical_props%tau, optical_props%ssa, optical_props%g,              &
-                                   sources%lay_source, sources%lev_source_inc, sources%lev_source_dec, &
+                                   optical_props%tau, optical_props%ssa, optical_props%g, &
+                                   sources%lay_source, sources%lev_source,                &
                                    sfc_emis_gpt, sources%sfc_source,       &
                                    inc_flux_diffuse,                       &
                                    gpt_flux_up, gpt_flux_dn)
@@ -396,8 +396,8 @@ contains
                                   logical(top_at_1, wl), n_quad_angs,         &
                                   secants, gauss_wts(1:n_quad_angs,n_quad_angs), &
                                   optical_props%tau,                 &
-                                  sources%lay_source, sources%lev_source_inc, &
-                                  sources%lev_source_dec,            &
+                                  sources%lay_source,                &
+                                  sources%lev_source,                &
                                   sfc_emis_gpt, sources%sfc_source,  &
                                   inc_flux_diffuse,                  &
                                   gpt_flux_up, gpt_flux_dn,          &

--- a/rte-frontend/mo_source_functions.F90
+++ b/rte-frontend/mo_source_functions.F90
@@ -30,10 +30,8 @@ module mo_source_functions
   type, extends(ty_optical_props), public :: ty_source_func_lw
     real(wp), allocatable, dimension(:,:,:) :: lay_source
         !! Planck source at layer average temperature (ncol, nlay, ngpt)
-    real(wp), allocatable, dimension(:,:,:) :: lev_source_inc
-        !! Planck source at layer edge in increasing ilay direction (ncol, nlay+1, ngpt)
-    real(wp), allocatable, dimension(:,:,:) :: lev_source_dec
-        !! Planck source at layer edge in decreasing ilay direction (ncol, nlay+1, ngpt)
+    real(wp), allocatable, dimension(:,:,:) :: lev_source
+        !! Planck source at layer edge (ncol, nlay+1, ngpt)
     real(wp), allocatable, dimension(:,:  ) :: sfc_source
         !! Planck function at surface temperature
     real(wp), allocatable, dimension(:,:  ) :: sfc_source_Jac
@@ -102,13 +100,11 @@ contains
     if(allocated(this%sfc_source))     deallocate(this%sfc_source)
     if(allocated(this%sfc_source_Jac)) deallocate(this%sfc_source_Jac)
     if(allocated(this%lay_source))     deallocate(this%lay_source)
-    if(allocated(this%lev_source_inc)) deallocate(this%lev_source_inc)
-    if(allocated(this%lev_source_dec)) deallocate(this%lev_source_dec)
+    if(allocated(this%lev_source))     deallocate(this%lev_source)
 
     ngpt = this%get_ngpt()
-    allocate(this%sfc_source    (ncol,     ngpt), this%lay_source    (ncol,nlay,ngpt), &
-             this%lev_source_inc(ncol,nlay,ngpt), this%lev_source_dec(ncol,nlay,ngpt))
-    allocate(this%sfc_source_Jac(ncol,     ngpt))
+    allocate(this%sfc_source    (ncol,       ngpt), this%lay_source    (ncol,nlay,ngpt), &
+             this%lev_source    (ncol,nlay+1,ngpt), this%sfc_source_Jac(ncol,     ngpt))
   end function alloc_lw
   ! --------------------------------------------------------------
   function copy_and_alloc_lw(this, ncol, nlay, spectral_desc) result(err_message)
@@ -181,8 +177,7 @@ contains
     class(ty_source_func_lw),    intent(inout) :: this
 
     if(allocated(this%lay_source    )) deallocate(this%lay_source)
-    if(allocated(this%lev_source_inc)) deallocate(this%lev_source_inc)
-    if(allocated(this%lev_source_dec)) deallocate(this%lev_source_dec)
+    if(allocated(this%lev_source    )) deallocate(this%lev_source)
     if(allocated(this%sfc_source    )) deallocate(this%sfc_source)
     if(allocated(this%sfc_source_Jac)) deallocate(this%sfc_source_Jac)
     call this%ty_optical_props%finalize()
@@ -260,8 +255,7 @@ contains
     subset%sfc_source    (1:n,  :) = full%sfc_source    (start:start+n-1,  :)
     subset%sfc_source_Jac(1:n,  :) = full%sfc_source_Jac(start:start+n-1,  :)
     subset%lay_source    (1:n,:,:) = full%lay_source    (start:start+n-1,:,:)
-    subset%lev_source_inc(1:n,:,:) = full%lev_source_inc(start:start+n-1,:,:)
-    subset%lev_source_dec(1:n,:,:) = full%lev_source_dec(start:start+n-1,:,:)
+    subset%lev_source    (1:n,:,:) = full%lev_source    (start:start+n-1,:,:)
   end function get_subset_range_lw
   ! ------------------------------------------------------------------------------------------
   function get_subset_range_sw(full, start, n, subset) result(err_message)

--- a/rte-kernels/mo_rte_solver_kernels.F90
+++ b/rte-kernels/mo_rte_solver_kernels.F90
@@ -48,12 +48,12 @@ contains
   !>    using user-supplied weights
   !
   ! ---------------------------------------------------------------
-  subroutine lw_solver_noscat_oneangle(ncol, nlay, ngpt, top_at_1, D, weight,                              &
-                              tau, lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src, &
+  subroutine lw_solver_noscat_oneangle(ncol, nlay, ngpt, top_at_1, D, weight, &
+                              tau, lay_source, lev_source, sfc_emis, sfc_src, &
                               incident_flux,    &
                               flux_up, flux_dn, &
                               do_broadband, broadband_up, broadband_dn, &
-                              do_Jacobians, sfc_srcJac, flux_upJac,               &
+                              do_Jacobians, sfc_srcJac, flux_upJac,     &
                               do_rescaling, ssa, g)
     integer,                               intent(in   ) :: ncol, nlay, ngpt ! Number of columns, layers, g-points
     logical(wl),                           intent(in   ) :: top_at_1
@@ -61,11 +61,7 @@ contains
     real(wp),                              intent(in   ) :: weight       ! quadrature weight
     real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: tau          ! Absorption optical thickness []
     real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lay_source   ! Planck source at layer average temperature [W/m2]
-    ! Planck source at layer edge for radiation in increasing/decreasing ilay direction
-    ! lev_source_dec applies the mapping in layer i to the Planck function at layer i
-    ! lev_source_inc applies the mapping in layer i to the Planck function at layer i+1
-    real(wp), dimension(ncol,nlay,  ngpt), target, &
-                                           intent(in   ) :: lev_source_inc, lev_source_dec
+    real(wp), dimension(ncol,nlay+1,ngpt), intent(in   ) :: lev_source   ! Planck source at layer edge  [W/m2]
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_emis     ! Surface emissivity      []
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_src      ! Surface source function [W/m2]
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: incident_flux! Boundary condition for flux [W/m2]
@@ -91,8 +87,6 @@ contains
     real(wp), dimension(ncol,nlay) :: source_dn, source_up
     real(wp), dimension(ncol     ) :: sfc_albedo
 
-    real(wp), dimension(:,:,:), pointer :: lev_source_up, lev_source_dn ! Mapping increasing/decreasing indicies to up/down
-
     real(wp), parameter :: pi = acos(-1._wp)
     ! loc_fluxes hold a single g-point flux if fluxes are being integrated instead of returned
     !   with spectral detail
@@ -115,22 +109,14 @@ contains
     real(wp)                         :: ssal, wb, scaleTau
     real(wp), dimension(ncol,nlay  ) :: An, Cn
     real(wp), dimension(ncol,nlay+1) :: gpt_flux_Jac
-    real(wp), dimension(ncol,nlay+1) :: lev_source
     ! ------------------------------------
     ! Which way is up?
-    ! Level Planck sources for upward and downward radiation
-    ! When top_at_1, lev_source_up => lev_source_dec
-    !                lev_source_dn => lev_source_inc, and vice-versa
     if(top_at_1) then
       top_level = 1
       sfc_level = nlay+1
-      lev_source_up => lev_source_dec
-      lev_source_dn => lev_source_inc
     else
       top_level = nlay+1
       sfc_level = 1
-      lev_source_up => lev_source_inc
-      lev_source_dn => lev_source_dec
     end if
 
     !
@@ -199,14 +185,8 @@ contains
       !
       ! Source function for diffuse radiation
       !
-      !
-      ! If we combine sources here we don't need the pointers or assignments above 
-      !
-      call lw_combine_sources(ncol, nlay, top_at_1, &
-                              lev_source_inc(:,:,igpt), lev_source_dec(:,:,igpt), &
-                              lev_source)
       call lw_source_noscat(ncol, nlay, top_at_1, &
-                            lay_source(:,:,igpt), lev_source, &
+                            lay_source(:,:,igpt), lev_source(:,:,igpt), &
                             tau_loc, trans, source_dn, source_up)
       !
       ! Transport down
@@ -268,7 +248,7 @@ contains
   subroutine lw_solver_noscat(ncol, nlay, ngpt, top_at_1, &
                               nmus, Ds, weights,          &
                               tau,                        &
-                              lay_source, lev_source_inc, lev_source_dec, &
+                              lay_source, lev_source,     &
                               sfc_emis, sfc_src,          &
                               inc_flux,                   &
                               flux_up, flux_dn,           &
@@ -290,10 +270,8 @@ contains
                                                             !! Absorption optical thickness []
     real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lay_source
                                                             !! Planck source at layer average temperature [W/m2]
-    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_inc
-                                        !! Planck source at layer edge for radiation in increasing ilay direction [W/m2]
-    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_dec
-                                        !! Planck source at layer edge for radiation in decreasing ilay direction [W/m2]
+    real(wp), dimension(ncol,nlay+1,ngpt), intent(in   ) :: lev_source
+                                                            !! Planck source at layer edge for radiation[W/m2]
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_emis
                                                             !! Surface emissivity      []
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_src
@@ -334,8 +312,8 @@ contains
     ! For the first angle output arrays store total flux
     !
     call lw_solver_noscat_oneangle(ncol, nlay, ngpt, &
-                          top_at_1, Ds(:,:,1), weights(1), tau, &
-                          lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src, &
+                          top_at_1, Ds(:,:,1), weights(1), tau,      &
+                          lay_source, lev_source, sfc_emis, sfc_src, &
                           inc_flux,         &
                           flux_up, flux_dn, &
                           do_broadband, broadband_up, broadband_dn, &
@@ -365,7 +343,7 @@ contains
     do imu = 2, nmus
       call lw_solver_noscat_oneangle(ncol, nlay, ngpt, &
                             top_at_1, Ds(:,:,imu), weights(imu), tau, &
-                            lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src, &
+                            lay_source, lev_source, sfc_emis, sfc_src, &
                             inc_flux,         &
                             this_flux_up,  this_flux_dn, &
                             do_broadband, this_broadband_up, this_broadband_dn, &
@@ -398,7 +376,7 @@ contains
   ! -------------------------------------------------------------------------------------------------
    subroutine lw_solver_2stream (ncol, nlay, ngpt, top_at_1, &
                                  tau, ssa, g,                &
-                                 lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src, &
+                                 lay_source, lev_source, sfc_emis, sfc_src, &
                                  inc_flux,                   &
                                  flux_up, flux_dn) bind(C, name="rte_lw_solver_2stream")
     integer,                               intent(in   ) :: ncol, nlay, ngpt
@@ -409,10 +387,8 @@ contains
                                                             !! Optical thickness, single-scattering albedo, asymmetry parameter []
     real(wp), dimension(ncol,nlay,  ngpt),   intent(in   ) :: lay_source
                                                             !! Planck source at layer average temperature [W/m2]
-    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_inc
-                                          !! Planck source at layer edge for radiation in increasing ilay direction [W/m2]
-    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_dec
-                                          !! Planck source at layer edge for radiation in decreasing ilay direction [W/m2]
+    real(wp), dimension(ncol,nlay+1,ngpt), intent(in   ) :: lev_source
+                                                            !! Planck source at layer edge temperature  [W/m2]
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_emis
                                                             !! Surface emissivity      []
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_src
@@ -425,20 +401,12 @@ contains
     integer :: igpt, top_level
     real(wp), dimension(ncol,nlay  ) :: Rdif, Tdif, gamma1, gamma2
     real(wp), dimension(ncol       ) :: sfc_albedo
-    real(wp), dimension(ncol,nlay+1) :: lev_source
     real(wp), dimension(ncol,nlay  ) :: source_dn, source_up
     real(wp), dimension(ncol       ) :: source_sfc
     ! ------------------------------------
     top_level = nlay+1
     if(top_at_1) top_level = 1
     do igpt = 1, ngpt
-      !
-      ! RRTMGP provides source functions at each level using the spectral mapping
-      !   of each adjacent layer. Combine these for two-stream calculations
-      !
-      call lw_combine_sources(ncol, nlay, top_at_1, &
-                              lev_source_inc(:,:,igpt), lev_source_dec(:,:,igpt), &
-                              lev_source)
       !
       ! Cell properties: reflection, transmission for diffuse radiation
       !   Coupling coefficients needed for source function
@@ -939,39 +907,6 @@ contains
 
     end do
   end subroutine lw_two_stream
-  ! -------------------------------------------------------------------------------------------------
-  !
-  ! Source function combination
-  ! RRTMGP provides two source functions at each level
-  !   using the spectral mapping from each of the adjascent layers.
-  !   Need to combine these for use in two-stream calculation.
-  !
-  ! -------------------------------------------------------------------------------------------------
-  subroutine lw_combine_sources(ncol, nlay, top_at_1, &
-                                lev_src_inc, lev_src_dec, lev_source)
-    integer,                           intent(in ) :: ncol, nlay
-    logical(wl),                       intent(in ) :: top_at_1
-    real(wp), dimension(ncol, nlay  ), intent(in ) :: lev_src_inc, lev_src_dec
-    real(wp), dimension(ncol, nlay+1), intent(out) :: lev_source
-
-    integer :: icol, ilay
-    ! ---------------------------------------------------------------
-    ilay = 1
-    do icol = 1,ncol
-      lev_source(icol, ilay) =        lev_src_dec(icol, ilay)
-    end do
-    do ilay = 2, nlay
-      do icol = 1,ncol
-        lev_source(icol, ilay) = sqrt(lev_src_dec(icol, ilay) * &
-                                      lev_src_inc(icol, ilay-1))
-      end do
-    end do
-    ilay = nlay+1
-    do icol = 1,ncol
-      lev_source(icol, ilay) =        lev_src_inc(icol, ilay-1)
-    end do
-
-  end subroutine lw_combine_sources
   ! ---------------------------------------------------------------
   !
   ! Compute LW source function for upward and downward emission at levels using linear-in-tau assumption


### PR DESCRIPTION
The original formulation of RRTMGP uses separate spectral maps for upwelling and downwelling radiation at each level. Here they are combined as sqrt(map1 * map2). This reduces memory traffic between gas optics and solver by about 25% and makes the solvers more generic. 

Differences introduced to the test cases are of order 0.06 W/m2. This exceeds the threshold we've been using to check for equivalence (7e-4). In this iteration the threshold has been relaxed to allow the tests to pass - is this the right approach, or would it be better to establish new test data? 