### PR TITLE
Run CI jobs on Levante via GitLab

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -1,0 +1,89 @@
+name: GitLab CI
+on:
+  push:
+    branches-ignore:
+    - documentation
+  pull_request:
+    branches-ignore:
+    - documentation
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  #
+  # Deferred GitLab pipelines on Levante at DKRZ (see .gitlab/levante.yml):
+  #
+  levante-init:
+    if: |
+      github.repository_owner == 'earth-system-radiation' &&
+        ( github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.owner.login == github.repository_owner )
+    runs-on: ubuntu-latest
+    outputs:
+      ref-name: ${{ steps.g-push-rev.outputs.ref-name }}
+      pipeline-id: ${{ steps.gl-trigger-pipeline.outputs.pipeline-id }}
+    steps:
+    #
+    # Check out GitHub repository
+    #
+    - name: Check out GitHub repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    #
+    # Push to GitLab repository
+    #
+    - name: Push to GitLab repository
+      id: g-push-rev
+      uses: "skosukhin/git-ci-hub-lab/g-push-rev@v1"
+      with:
+        remote-url: ${{ vars.DKRZ_GITLAB_SERVER }}/${{ vars.DKRZ_GITLAB_PROJECT }}.git
+        password: ${{ secrets.DKRZ_GITLAB_TOKEN }}
+        ref-type: tag
+        ref-message: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        force-push: true
+    #
+    # Trigger GitLab CI/CD Pipeline
+    #
+    - name: Trigger GitLab CI/CD Pipeline
+      id: gl-trigger-pipeline
+      uses: "skosukhin/git-ci-hub-lab/gl-trigger-pipeline@v1"
+      with:
+        server-url: ${{ vars.DKRZ_GITLAB_SERVER }}
+        project-name: ${{ vars.DKRZ_GITLAB_PROJECT }}
+        token: ${{ secrets.DKRZ_GITLAB_TRIGGER_TOKEN }}
+        ref-name: ${{ steps.g-push-rev.outputs.ref-name }}
+        expected-sha: ${{ github.sha }}
+  levante:
+    runs-on: ubuntu-latest
+    needs: levante-init
+    strategy:
+      fail-fast: false
+      matrix:
+        config-name: [nvhpc-gpu-openacc-DP, nvhpc-gpu-openacc-SP]
+    steps:
+    #
+    # Build, run and check (fetch the log)
+    #
+    - name: Build, run and check (fetch the log)
+      uses: "skosukhin/git-ci-hub-lab/gl-attach-job@v1"
+      with:
+        server-url: ${{ vars.DKRZ_GITLAB_SERVER }}
+        project-name: ${{ vars.DKRZ_GITLAB_PROJECT }}
+        token: ${{ secrets.DKRZ_GITLAB_TOKEN }}
+        pipeline-id: ${{ needs.levante-init.outputs.pipeline-id }}
+        job-name: ${{ matrix.config-name }}
+  levante-cleanup:
+    runs-on: ubuntu-latest
+    needs: [levante-init, levante]
+    if: always() && needs.levante-init.result != 'skipped'
+    continue-on-error: true
+    steps:
+    - uses: "skosukhin/git-ci-hub-lab/g-delete-ref@v1"
+      with:
+        remote-url: ${{ vars.DKRZ_GITLAB_SERVER }}/${{ vars.DKRZ_GITLAB_PROJECT }}.git
+        password: ${{ secrets.DKRZ_GITLAB_TOKEN }}
+        ref-type: tag
+        ref-name: ${{ needs.levante-init.outputs.ref-name }}

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -1,0 +1,73 @@
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+
+include:
+  - project: 'anw_dienste/ci-templates'
+    file: '.slurm-ci.yml'
+
+variables:
+  SCHEDULER_PARAMETERS: >-
+    --account=mh0287
+    --partition=gpu
+    --gpus=1
+    --time=05:00
+
+.build-common:
+  extends: .default
+  variables:
+    # Core variables:
+    FC: /sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/compilers/bin/nvfortran
+    #   Production flags for ICON model:
+    FCFLAGS: -g -O2 -Mrecursive -Mallocatable=03 -Mstack_arrays -Minfo=accel,inline -acc=gpu,verystrict -gpu=cc80,cuda11.7 -DRTE_USE_${FPMODEL}
+    # Convenience variables:
+    NFHOME: /sw/spack-levante/netcdf-fortran-4.5.4-syv4qr
+    NCHOME: /sw/spack-levante/netcdf-c-4.9.0-gc7kgj
+    PYHOME: /sw/spack-levante/mambaforge-22.9.0-2-Linux-x86_64-kptncg
+    #   Suppress an irrelevant but annoying error message:
+    PROJ_LIB: ${PYHOME}/share/proj
+    # Make variables:
+    FCINCLUDE: -I${NFHOME}/include
+    LDFLAGS: -L${NFHOME}/lib -L${NCHOME}/lib
+    RRTMGP_ROOT: ${CI_PROJECT_DIR}
+    RRTMGP_DATA: ${CI_PROJECT_DIR}/rrtmgp-data
+    RTE_KERNELS: accel
+  before_script:
+    - module purge
+    - module load git
+    # Extend the existing environment variables:
+    - export PATH="${PYHOME}/bin:${PATH}"
+    - export LD_LIBRARY_PATH="${NFHOME}/lib:${NCHOME}/lib:${LD_LIBRARY_PATH-}"
+    # The -Mstack_arrays compiler flag requires a large stack:
+    - ulimit -s unlimited
+  script:
+    #
+    # Build libraries, examples and tests
+    #
+    - ${FC} --version
+    - make libs
+    - make -C build separate-libs
+    #
+    # Check out data
+    #
+    - git clone --depth 1 https://github.com/earth-system-radiation/rrtmgp-data.git "${RRTMGP_DATA}"
+    #
+    # Run examples and tests
+    #
+    - make tests
+    #
+    # Compare the results
+    #
+    - make check
+
+nvhpc-gpu-openacc-DP:
+  extends: .build-common
+  variables:
+    FPMODEL: DP
+    FAILURE_THRESHOLD: "5.8e-2"
+
+nvhpc-gpu-openacc-SP:
+  extends: .build-common
+  variables:
+    FPMODEL: SP
+    FAILURE_THRESHOLD: "3.5e-1"


### PR DESCRIPTION
This implements CI jobs that run the tests on the GPU partition of [Levante](https://docs.dkrz.de/doc/levante/index.html).

The compiler version and flags are what we currently use to build [ICON](https://www.icon-model.org/) by default.

For security reasons, the jobs are skipped for PRs from the forks.