### PR TITLE
Adjust tolerances, fix error in accelerator source function kernel

### DIFF
--- a/examples/all-sky/all_tests.sh
+++ b/examples/all-sky/all_tests.sh
@@ -1,3 +1,4 @@
+set -eux
 ./rrtmgp_allsky 24 72 1 rrtmgp-allsky-lw.nc \
 	    ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc ${RRTMGP_DATA}/rrtmgp-aerosols-merra-lw.nc 
 ./rrtmgp_allsky 24 72 1 rrtmgp-allsky-sw.nc \

--- a/rrtmgp-frontend/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp-frontend/mo_gas_optics_rrtmgp.F90
@@ -304,17 +304,25 @@ contains
 
     !
     ! Interpolate source function
-    ! present status of optional argument is passed to source()
+    ! present status of optional argument should be passed to source()
+    !    but nvfortran (and PGI Fortran before it) do not do so
     !
-    error_msg = source(this,                               &
-                       ncol, nlay, nband, ngpt,            &
-                       play, plev, tlay, tsfc,             &
-                       jtemp, jpress, jeta, tropo, fmajor, &
-                       sources,                            &
-                       tlev)
     if(present(tlev)) then   
+      error_msg = source(this,                               &
+                         ncol, nlay, nband, ngpt,            &
+                         play, plev, tlay, tsfc,             &
+                         jtemp, jpress, jeta, tropo, fmajor, &
+                         sources,                            &
+                         tlev)
       !$acc        exit data      delete(tlev)
       !$omp target exit data map(release:tlev)
+    else 
+      error_msg = source(this,                               &
+                         ncol, nlay, nband, ngpt,            &
+                         play, plev, tlay, tsfc,             &
+                         jtemp, jpress, jeta, tropo, fmajor, &
+                         sources)
+
     end if 
     !$acc        exit data      delete(tsfc)
     !$omp target exit data map(release:tsfc)

--- a/tests/all_tests.sh
+++ b/tests/all_tests.sh
@@ -1,3 +1,4 @@
+set -eux
 ./check_equivalence test_atmospheres.nc ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc 
 ./check_equivalence test_atmospheres.nc ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc 
 ./check_equivalence test_atmospheres.nc ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc 

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -278,6 +278,10 @@ program rte_check_equivalence
     if(.not. allclose(tst_flux_up, ref_flux_up, tol=4._wp) .or. &
        .not. allclose(tst_flux_dn, ref_flux_dn, tol=4._wp) )    &
       call report_err(" Vertical invariance failure")
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol=4._wp)) & 
+      print *, "up:", maxval((tst_flux_up - ref_flux_up)/spacing(tst_flux_up))  
+    if(.not. allclose(tst_flux_dn, ref_flux_dn, tol=4._wp)) & 
+      print *, "dn:", maxval((tst_flux_dn - ref_flux_dn)/spacing(tst_flux_dn))  
     print *, "  Vertical orientation invariance"
     ! -------------------------------------------------------
     !

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -489,42 +489,63 @@ contains
     character(32), &
               dimension(gas_concs%get_num_gases()) &
                                   :: gc_gas_names
+    ! ifort was failing this end-to-end test using the accelerator kernels
+    !   The failure looks to be in the computation of optical properties. Setting
+    !   do_whole_shebang = .false. vertically reverses the existing optical properties.
     !
-    ! Reverse the orientation of the problem
-    !
-    p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
-    t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
-    p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
-    t_lev  (:,:) = t_lev  (:,(nlay+1):1:-1)
-    top_at_1 = .not. top_at_1
-    !
-    ! No direct access to gas concentrations so use the classes
-    !   This also tests otherwise uncovered routines for ty_gas_concs
-    !
-    gc_gas_names(:) = gas_concs%get_gas_names()
-    call stop_on_err(gas_concs_vr%init(gc_gas_names(:)))
-    do i = 1, gas_concs%get_num_gases()
-      call stop_on_err(gas_concs%get_vmr(gc_gas_names(i), vmr))
-      vmr(:,:)  = vmr(:,nlay:1:-1)
-      call stop_on_err(gas_concs_vr%set_vmr(gc_gas_names(i), vmr))
-    end do
+#ifdef __INTEL_COMPILER
+    logical, parameter :: do_whole_shebang = .false.
+#else
+    logical, parameter :: do_whole_shebang = .true.
+#endif
 
-    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
-                                       t_lay, sfc_t, &
-                                       gas_concs_vr, &
-                                       atmos,        &
-                                       lw_sources,   &
-                                       tlev=t_lev))
+    if (do_whole_shebang) then
+        print *, "    Doing the end-to-end problem"
+        !
+        ! Reverse the orientation of the problem
+        !
+        p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
+        t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
+        p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
+        t_lev  (:,:) = t_lev  (:,(nlay+1):1:-1)
+        top_at_1 = .not. top_at_1
+        !
+        ! No direct access to gas concentrations so use the classes
+        !   This also tests otherwise uncovered routines for ty_gas_concs
+        !
+        gc_gas_names(:) = gas_concs%get_gas_names()
+        call stop_on_err(gas_concs_vr%init(gc_gas_names(:)))
+        do i = 1, gas_concs%get_num_gases()
+          call stop_on_err(gas_concs%get_vmr(gc_gas_names(i), vmr))
+          vmr(:,:)  = vmr(:,nlay:1:-1)
+          call stop_on_err(gas_concs_vr%set_vmr(gc_gas_names(i), vmr))
+        end do
+
+        call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                           t_lay, sfc_t, &
+                                           gas_concs_vr, &
+                                           atmos,        &
+                                           lw_sources,   &
+                                           tlev=t_lev))
+    else
+      print *, "    Skipping gas optics calculation"
+      atmos%tau            (:,:,:) =  atmos%tau            (:, nlay   :1:-1,:)
+      lw_sources%lay_source(:,:,:) =  lw_sources%lay_source(:, nlay   :1:-1,:)
+      lw_sources%lev_source(:,:,:) =  lw_sources%lev_source(:,(nlay+1):1:-1,:)
+      top_at_1 = .not. top_at_1
+    end if
     call stop_on_err(rte_lw(atmos, top_at_1, &
                             lw_sources,      &
                             sfc_emis,        &
                             fluxes))
     tst_flux_up(:,:) = tst_flux_up(:,(nlay+1):1:-1)
     tst_flux_dn(:,:) = tst_flux_dn(:,(nlay+1):1:-1)
-    p_lay      (:,:) = p_lay      (:, nlay   :1:-1)
-    t_lay      (:,:) = t_lay      (:, nlay   :1:-1)
-    p_lev      (:,:) = p_lev      (:,(nlay+1):1:-1)
-    t_lev      (:,:) = t_lev      (:,(nlay+1):1:-1)
+    if (do_whole_shebang) then
+      p_lay      (:,:) = p_lay      (:, nlay   :1:-1)
+      t_lay      (:,:) = t_lay      (:, nlay   :1:-1)
+      p_lev      (:,:) = p_lev      (:,(nlay+1):1:-1)
+      t_lev      (:,:) = t_lev      (:,(nlay+1):1:-1)
+    end do 
     top_at_1 = .not. top_at_1
   end subroutine lw_clear_sky_vr
   ! ----------------------------------------------------------------------------

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -278,10 +278,6 @@ program rte_check_equivalence
     if(.not. allclose(tst_flux_up, ref_flux_up, tol=4._wp) .or. &
        .not. allclose(tst_flux_dn, ref_flux_dn, tol=4._wp) )    &
       call report_err(" Vertical invariance failure")
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol=4._wp)) & 
-      print *, "up:", maxval((tst_flux_up - ref_flux_up)/spacing(tst_flux_up))  
-    if(.not. allclose(tst_flux_dn, ref_flux_dn, tol=4._wp)) & 
-      print *, "dn:", maxval((tst_flux_dn - ref_flux_dn)/spacing(tst_flux_dn))  
     print *, "  Vertical orientation invariance"
     ! -------------------------------------------------------
     !
@@ -493,63 +489,43 @@ contains
     character(32), &
               dimension(gas_concs%get_num_gases()) &
                                   :: gc_gas_names
-    ! ifort was failing this end-to-end test using the accelerator kernels
-    !   The failure looks to be in the computation of optical properties. Setting
-    !   do_whole_shebang = .false. vertically reverses the existing optical properties.
+
     !
-#ifdef __INTEL_COMPILER
-    logical, parameter :: do_whole_shebang = .false.
-#else
-    logical, parameter :: do_whole_shebang = .true.
-#endif
+    ! Reverse the orientation of the problem
+    !
+    p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
+    t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
+    p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
+    t_lev  (:,:) = t_lev  (:,(nlay+1):1:-1)
+    top_at_1 = .not. top_at_1
+    !
+    ! No direct access to gas concentrations so use the classes
+    !   This also tests otherwise uncovered routines for ty_gas_concs
+    !
+    gc_gas_names(:) = gas_concs%get_gas_names()
+    call stop_on_err(gas_concs_vr%init(gc_gas_names(:)))
+    do i = 1, gas_concs%get_num_gases()
+      call stop_on_err(gas_concs%get_vmr(gc_gas_names(i), vmr))
+      vmr(:,:)  = vmr(:,nlay:1:-1)
+      call stop_on_err(gas_concs_vr%set_vmr(gc_gas_names(i), vmr))
+    end do
 
-    if (do_whole_shebang) then
-        print *, "    Doing the end-to-end problem"
-        !
-        ! Reverse the orientation of the problem
-        !
-        p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
-        t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
-        p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
-        t_lev  (:,:) = t_lev  (:,(nlay+1):1:-1)
-        top_at_1 = .not. top_at_1
-        !
-        ! No direct access to gas concentrations so use the classes
-        !   This also tests otherwise uncovered routines for ty_gas_concs
-        !
-        gc_gas_names(:) = gas_concs%get_gas_names()
-        call stop_on_err(gas_concs_vr%init(gc_gas_names(:)))
-        do i = 1, gas_concs%get_num_gases()
-          call stop_on_err(gas_concs%get_vmr(gc_gas_names(i), vmr))
-          vmr(:,:)  = vmr(:,nlay:1:-1)
-          call stop_on_err(gas_concs_vr%set_vmr(gc_gas_names(i), vmr))
-        end do
-
-        call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
-                                           t_lay, sfc_t, &
-                                           gas_concs_vr, &
-                                           atmos,        &
-                                           lw_sources,   &
-                                           tlev=t_lev))
-    else
-      print *, "    Skipping gas optics calculation"
-      atmos%tau            (:,:,:) =  atmos%tau            (:, nlay   :1:-1,:)
-      lw_sources%lay_source(:,:,:) =  lw_sources%lay_source(:, nlay   :1:-1,:)
-      lw_sources%lev_source(:,:,:) =  lw_sources%lev_source(:,(nlay+1):1:-1,:)
-      top_at_1 = .not. top_at_1
-    end if
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs_vr, &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev=t_lev))
     call stop_on_err(rte_lw(atmos, top_at_1, &
                             lw_sources,      &
                             sfc_emis,        &
                             fluxes))
     tst_flux_up(:,:) = tst_flux_up(:,(nlay+1):1:-1)
     tst_flux_dn(:,:) = tst_flux_dn(:,(nlay+1):1:-1)
-    if (do_whole_shebang) then
-      p_lay      (:,:) = p_lay      (:, nlay   :1:-1)
-      t_lay      (:,:) = t_lay      (:, nlay   :1:-1)
-      p_lev      (:,:) = p_lev      (:,(nlay+1):1:-1)
-      t_lev      (:,:) = t_lev      (:,(nlay+1):1:-1)
-    end if
+    p_lay      (:,:) = p_lay      (:, nlay   :1:-1)
+    t_lay      (:,:) = t_lay      (:, nlay   :1:-1)
+    p_lev      (:,:) = p_lev      (:,(nlay+1):1:-1)
+    t_lev      (:,:) = t_lev      (:,(nlay+1):1:-1)
     top_at_1 = .not. top_at_1
   end subroutine lw_clear_sky_vr
   ! ----------------------------------------------------------------------------

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -275,8 +275,8 @@ program rte_check_equivalence
     ! Orientation invariance 
     !
     call lw_clear_sky_vr
-    if(.not. allclose(tst_flux_up, ref_flux_up) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn) )    & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol=4._wp) .or. &
+       .not. allclose(tst_flux_dn, ref_flux_dn, tol=4._wp) )    &
       call report_err(" Vertical invariance failure")
     print *, "  Vertical orientation invariance"
     ! -------------------------------------------------------
@@ -411,9 +411,9 @@ program rte_check_equivalence
     !   Threshold of 4x spacing() works on CPUs but 8x is needed for GPUs
     !
     call sw_clear_sky_tsi
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 8._wp) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 8._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 8._wp))    &  
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. &
+       .not. allclose(tst_flux_dn, ref_flux_dn, tol =  8._wp) .or. &
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol =  8._wp))     &
       call report_err("  Changing TSI fails")
     print *, "  TSI invariance"
     ! -------------------------------------------------------
@@ -432,9 +432,9 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 6._wp) .or. & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 8._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 6._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 6._wp))    &  
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 8._wp))    &  
       call report_err("  halving/doubling fails")
 
     call increment_with_1scl
@@ -442,7 +442,7 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 6._wp) .or. & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 8._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 6._wp) .or. & 
        .not. allclose(tst_flux_dir,ref_flux_dir,tol = 6._wp))    &  
       call report_err("  Incrementing with 1scl fails")
@@ -453,9 +453,9 @@ program rte_check_equivalence
                                        atmos,        &
                                        toa_flux))
    call increment_with_2str
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 6._wp) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 6._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 6._wp))    &  
+   if(.not. allclose(tst_flux_up, ref_flux_up, tol = 8._wp) .or. & 
+      .not. allclose(tst_flux_dn, ref_flux_dn, tol = 6._wp) .or. & 
+      .not. allclose(tst_flux_dir,ref_flux_dir,tol = 6._wp))    &  
       call report_err("  Incrementing with 2str fails")
 
     call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
@@ -468,7 +468,7 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 6._wp) .or. & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 8._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 6._wp) .or. & 
        .not. allclose(tst_flux_dir,ref_flux_dir,tol = 6._wp))    &  
       call report_err("  Incrementing with nstr fails")

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -545,7 +545,7 @@ contains
       t_lay      (:,:) = t_lay      (:, nlay   :1:-1)
       p_lev      (:,:) = p_lev      (:,(nlay+1):1:-1)
       t_lev      (:,:) = t_lev      (:,(nlay+1):1:-1)
-    end do 
+    end if
     top_at_1 = .not. top_at_1
   end subroutine lw_clear_sky_vr
   ! ----------------------------------------------------------------------------


### PR DESCRIPTION
In the course of adjusting tolerances to match @skosukhin's values I uncovered a bug in the LW source function. This PR includes the bug fix and the adjusted tolerances, so more tests pass (nvfortran 23.9 is still failing with a missing pointer)