### PR TITLE
Fix the intent in lw_transport_noscat_up

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -73,10 +73,6 @@ jobs:
         include:
           # The tests are not experimental by default:
           - experimental: false
-          - config-name: nag-cpu-accel-DP
-            experimental: true
-          #- config-name: nag-cpu-accel-SP
-          #  experimental: true
     steps:
     #
     # Build, run and check (fetch the log)

--- a/rte-kernels/accel/mo_rte_solver_kernels.F90
+++ b/rte-kernels/accel/mo_rte_solver_kernels.F90
@@ -790,7 +790,7 @@ contains
     logical(wl),                           intent(in   ) :: top_at_1   !
     real(wp), dimension(ncol,nlay  ,ngpt), intent(in   ) :: trans      ! transmissivity = exp(-tau)
     real(wp), dimension(ncol,nlay  ,ngpt), intent(in   ) :: source_up  ! Diffuse radiation emitted by the layer
-    real(wp), dimension(ncol,nlay+1,ngpt), intent(  out) :: radn_up    ! Radiances [W/m2-str]
+    real(wp), dimension(ncol,nlay+1,ngpt), intent(inout) :: radn_up    ! Radiances [W/m2-str]
     logical(wl),                           intent(in   ) :: do_Jacobians
     real(wp), dimension(ncol,nlay+1,ngpt), intent(inout) :: radn_upJac    ! surface temperature Jacobian of Radiances [W/m2-str / K]
     ! Local variables


### PR DESCRIPTION
This should make the `nag-cpu-accel-DP` CI job pass (as soon as Levante is back online).

The wrong intent leads to the multiplication by `NaN` [here](https://github.com/earth-system-radiation/rte-rrtmgp/blob/1949a8aa9897cc4367dad8df90bc59f92e5d80d9/rte-kernels/accel/mo_rte_solver_kernels.F90#L825).