### PR TITLE
Reduce use of CI via manual runs

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
-workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   Containerized-CI:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
+workflow_dispatch:
 
 jobs:
   Containerized-CI:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -1,8 +1,9 @@
 name: Continuous integration in a box
 on:
   push:
-    branches-ignore:
-    - documentation
+    branches:
+    - main
+    - develop
   pull_request:
     branches-ignore:
     - documentation

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
+workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
-workflow_dispatch:
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,9 @@
 name: Continuous Integration
 on:
   push:
-    branches-ignore:
-    - documentation
+    branches:
+    - main
+    - develop
   pull_request:
     branches-ignore:
     - documentation

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -1,8 +1,9 @@
 name: GitLab CI
 on:
   push:
-    branches-ignore:
-    - documentation
+    branches:
+    - main
+    - develop
   pull_request:
     branches-ignore:
     - documentation

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
+workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
-workflow_dispatch:
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
+workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches-ignore:
     - documentation
-workflow_dispatch:
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -1,8 +1,9 @@
 name: Self-hosted CI
 on:
   push:
-    branches-ignore:
-    - documentation
+    branches:
+    - main
+    - develop
   pull_request:
     branches-ignore:
     - documentation


### PR DESCRIPTION
This lays the groundwork for reducing the number of times the CI is run. The CI will only happen on PRs but can be invoked manually. 

@skosukhin Do we want to change the `on:` rules? 