### PR TITLE
Run CI jobs on Lumi via GitLab

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -100,3 +100,106 @@ jobs:
         ref-type: tag
         ref-name: ${{ needs.levante-init.outputs.ref-name }}
         force: true
+  #
+  # Deferred GitLab pipelines on Lumi at CSC (see .gitlab/lumi.yml):
+  #
+  lumi-init:
+    if: |
+      github.repository_owner == 'earth-system-radiation' &&
+        ( github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.owner.login == github.repository_owner )
+    runs-on: ubuntu-latest
+    outputs:
+      ref-name: ${{ steps.g-push-rev.outputs.ref-name }}
+      pipeline-id: ${{ steps.gl-create-pipeline.outputs.pipeline-id }}
+    steps:
+    #
+    # Check out GitHub repository
+    #
+    - name: Check out GitHub repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    #
+    # Push to GitLab repository
+    #
+    - name: Push to GitLab repository
+      id: g-push-rev
+      uses: "skosukhin/git-ci-hub-lab/g-push-rev@v1"
+      with:
+        remote-url: ${{ vars.GITLAB_SERVER }}/${{ vars.GITLAB_PROJECT }}.git
+        password: ${{ secrets.GITLAB_TOKEN }}
+        rev-id: ${{ github.sha }}
+        rev-signing-format: ssh
+        rev-signing-key: ${{ secrets.GITLAB_SIGNING_KEY }}
+        ref-type: tag
+        ref-message: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        force-push: true
+    #
+    # Create GitLab CI/CD Pipeline
+    #
+    - name: Create GitLab CI/CD Pipeline
+      id: gl-create-pipeline
+      uses: "skosukhin/git-ci-hub-lab/gl-create-pipeline@v1"
+      with:
+        server-url: ${{ vars.GITLAB_SERVER }}
+        project-name: ${{ vars.GITLAB_PROJECT }}
+        token: ${{ secrets.GITLAB_TOKEN }}
+        ref-name: ${{ steps.g-push-rev.outputs.ref-name }}
+        expected-sha: ${{ steps.g-push-rev.outputs.ref-commit }}
+    #
+    # Set up Python virtual environment (fetch the log)
+    #
+    - name: Set up Python virtual environment (fetch the log)
+      uses: "skosukhin/git-ci-hub-lab/gl-attach-job@v1"
+      with:
+        server-url: ${{ vars.GITLAB_SERVER }}
+        project-name: ${{ vars.GITLAB_PROJECT }}
+        token: ${{ secrets.GITLAB_TOKEN }}
+        pipeline-id: ${{ steps.gl-create-pipeline.outputs.pipeline-id }}
+        job-name: setup-python
+  lumi:
+    runs-on: ubuntu-latest
+    needs: lumi-init
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config-name:
+          - cce-gpu-openacc-DP
+          - cce-gpu-openacc-SP
+        include:
+          # The tests are not experimental by default:
+          - experimental: false
+    steps:
+    #
+    # Build, run and check (fetch the log)
+    #
+    - name: Build, run and check (fetch the log)
+      uses: "skosukhin/git-ci-hub-lab/gl-attach-job@v1"
+      with:
+        server-url: ${{ vars.GITLAB_SERVER }}
+        project-name: ${{ vars.GITLAB_PROJECT }}
+        token: ${{ secrets.GITLAB_TOKEN }}
+        pipeline-id: ${{ needs.lumi-init.outputs.pipeline-id }}
+        job-name: ${{ matrix.config-name }}
+  lumi-cleanup:
+    runs-on: ubuntu-latest
+    needs: [lumi-init, lumi]
+    if: always() && needs.lumi-init.result != 'skipped'
+    continue-on-error: true
+    steps:
+    - uses: "skosukhin/git-ci-hub-lab/gl-cancel-pipeline@v1"
+      with:
+        server-url: ${{ vars.GITLAB_SERVER }}
+        project-name: ${{ vars.GITLAB_PROJECT }}
+        token: ${{ secrets.GITLAB_TOKEN }}
+        pipeline-id: ${{ needs.lumi-init.outputs.pipeline-id }}
+    - uses: "skosukhin/git-ci-hub-lab/gl-delete-ref@v1"
+      with:
+        server-url: ${{ vars.GITLAB_SERVER }}
+        project-name: ${{ vars.GITLAB_PROJECT }}
+        token: ${{ secrets.GITLAB_TOKEN }}
+        ref-type: tag
+        ref-name: ${{ needs.lumi-init.outputs.ref-name }}
+        force: true

--- a/.gitlab/lumi.yml
+++ b/.gitlab/lumi.yml
@@ -1,0 +1,130 @@
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "api"
+
+default:
+  tags:
+    - lumi
+
+variables:
+  SCHEDULER_PARAMETERS: >-
+    --account=project_465000454
+    --nodes=1
+    --ntasks=1
+    --cpus-per-task=4
+    --mem-per-cpu=1G
+    --time=05:00
+    ${EXTRA_SCHEDULER_PARAMETERS}
+  EXTRA_SCHEDULER_PARAMETERS:
+
+.gpu:
+  variables:
+    EXTRA_SCHEDULER_PARAMETERS: >-
+      --partition=dev-g
+      --gpus=1
+
+.cpu:
+  variables:
+    EXTRA_SCHEDULER_PARAMETERS: >-
+      --partition=debug
+
+.cce:
+  variables:
+    # Core variables:
+    FC: ftn
+    # Convenience variables:
+    VERSION_FCFLAGS: -V
+    COMPILER_MODULES: PrgEnv-cray cce/16.0.1 craype-x86-milan
+
+.dp:
+  variables:
+    FPMODEL: DP
+    FAILURE_THRESHOLD: "5.8e-2"
+
+.sp:
+  variables:
+    FPMODEL: SP
+    FAILURE_THRESHOLD: "3.5e-1"
+
+#
+# Set up Python virtual environment
+#
+.python-common:
+  variables:
+    PYHOME: ${CI_PROJECT_DIR}/python-venv
+    FF_USE_FASTZIP: 1
+
+setup-python:
+  extends:
+    - .cpu
+    - .python-common
+  script:
+    - test ! -d "${PYHOME}" || exit 0
+    - module load cray-python
+    - python -m venv ${PYHOME}
+    - ${PYHOME}/bin/python -m pip install --upgrade pip
+    - ${PYHOME}/bin/python -m pip install dask[array] netCDF4 numpy xarray
+  cache:
+    # Update the key to regenerate the virtual environment:
+    key: python-venv-version-1
+    paths:
+      - ${PYHOME}
+  artifacts:
+    paths:
+      - ${PYHOME}
+    expire_in: 60 minutes
+
+.common:
+  extends: .python-common
+  needs:
+    - setup-python
+  variables:
+    # Make variables:
+    RRTMGP_ROOT: ${CI_PROJECT_DIR}
+    RRTMGP_DATA: ${CI_PROJECT_DIR}/rrtmgp-data
+  before_script:
+    - module --force purge
+    - module load ${COMPILER_MODULES} ${EXTRA_COMPILER_MODULES} cray-hdf5 cray-netcdf
+    # Extend the existing environment variables:
+    - export PATH="${PYHOME}/bin:${PATH}"
+  script:
+    #
+    # Build libraries, examples and tests
+    #
+    - ${FC} ${VERSION_FCFLAGS}
+    - make libs
+    - make -C build separate-libs
+    #
+    # Check out data
+    #
+    - git clone --depth 1 https://github.com/earth-system-radiation/rrtmgp-data.git "${RRTMGP_DATA}"
+    #
+    # Run examples and tests
+    #
+    - make tests
+    #
+    # Compare the results
+    #
+    - make check
+
+.cce-gpu-openacc:
+  extends:
+    - .gpu
+    - .cce
+    - .common
+  variables:
+    # Compiler flags used for ICON model:
+    FCFLAGS: -hacc -hadd_paren -Ktrap=divz,ovf,inv -hflex_mp=intolerant -hfp1 -g -DRTE_USE_${FPMODEL}
+    RTE_KERNELS: accel
+    # Convenience variables:
+    EXTRA_COMPILER_MODULES: craype-accel-amd-gfx90a rocm
+
+cce-gpu-openacc-DP:
+  extends:
+    - .dp
+    - .cce-gpu-openacc
+
+cce-gpu-openacc-SP:
+  extends:
+    - .dp
+    - .cce-gpu-openacc


### PR DESCRIPTION
This implements CI jobs that run the tests on the AMD GPU partition of [Lumi](https://www.lumi-supercomputer.eu).

The compiler version and flags are what we currently use to build [ICON](https://www.icon-model.org) by default.

For security reasons, the jobs are skipped for PRs from the forks.