### PR TITLE
Small refactoring for the build system

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -80,8 +80,8 @@ jobs:
       if: matrix.fortran-compiler != 'ifx' || matrix.rte-kernels != 'accel'
       run: |
         $FC --version
-        make libs
-        make -C build separate-libs
+        make -j4 libs
+        make -j4 -C build separate-libs
     #
     # Build libraries, examples and tests (expect failure)
     #
@@ -90,7 +90,7 @@ jobs:
       shell: bash
       run: |
         $FC --version
-        make libs 2> >(tee make.err >&2) && {
+        make -j4 libs 2> >(tee make.err >&2) && {
           echo "Unexpected success"
           exit 1
         } || {
@@ -106,7 +106,7 @@ jobs:
     #
     - name: Run examples and tests
       if: steps.build-success.outcome != 'skipped'
-      run: make tests
+      run: make -j4 tests
     #
     # Relax failure thresholds for single precision
     #
@@ -118,7 +118,7 @@ jobs:
     #
     - name: Compare the results
       if: steps.build-success.outcome != 'skipped'
-      run: make check
+      run: make -j4 check
     #
     # Generate validation plots
     #

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,15 +89,15 @@ jobs:
     - name: Build libraries, examples and tests
       run: |
         $FC --version
-        make libs
-        make -C build separate-libs
+        make -j4 libs
+        make -j4 -C build separate-libs
     #
     # Run examples and tests
     #
     - name: Run examples and tests
-      run: make tests
+      run: make -j4 tests
     #
     # Compare the results
     #
     - name: Compare the results
-      run: make check
+      run: make -j4 check

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -96,22 +96,22 @@ jobs:
     - name: Build libraries, examples and tests
       run: |
         $FC --version
-        make libs
-        make -C build separate-libs
+        make -j8 libs
+        make -j8 -C build separate-libs
     #
     # Run examples and tests (expect success)
     #
     - name: Run examples and tests (expect success)
       id: run-success
       if: matrix.config-name != 'cce-gpu-openmp'
-      run: make tests
+      run: make -j8 tests
     #
     # Run examples and tests (expect failure)
     #
     - name: Run examples and tests (expect failure)
       if: steps.run-success.outcome == 'skipped'
       run: |
-        make tests && {
+        make -j8 tests && {
           echo "Unexpected success"
           exit 1
         } || echo "Expected failure"
@@ -126,4 +126,4 @@ jobs:
     #
     - name: Compare the results
       if: steps.run-success.outcome != 'skipped'
-      run: make check
+      run: make -j8 check

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -77,8 +77,8 @@ variables:
     # Build libraries, examples and tests
     #
     - ${FC} ${VERSION_FCFLAGS}
-    - make libs
-    - make -C build separate-libs
+    - make -j8 libs
+    - make -j8 -C build separate-libs
     #
     # Check out data
     #
@@ -86,11 +86,11 @@ variables:
     #
     # Run examples and tests
     #
-    - make tests
+    - make -j8 tests
     #
     # Compare the results
     #
-    - make check
+    - make -j8 check
 
 .nvhpc-gpu-openacc:
   extends:

--- a/.gitlab/lumi.yml
+++ b/.gitlab/lumi.yml
@@ -92,8 +92,8 @@ setup-python:
     # Build libraries, examples and tests
     #
     - ${FC} ${VERSION_FCFLAGS}
-    - make libs
-    - make -C build separate-libs
+    - make -j8 libs
+    - make -j8 -C build separate-libs
     #
     # Check out data
     #
@@ -101,11 +101,11 @@ setup-python:
     #
     # Run examples and tests
     #
-    - make tests
+    - make -j8 tests
     #
     # Compare the results
     #
-    - make check
+    - make -j8 check
 
 .cce-gpu-openacc:
   extends:

--- a/Makefile
+++ b/Makefile
@@ -5,27 +5,27 @@
 all:    libs tests check docs
 
 libs:
-	make -C build -j
-	make -C tests -j 1
-	make -C examples/all-sky -j
-	make -C examples/rfmip-clear-sky -j
+	$(MAKE) -C build
+	$(MAKE) -C tests
+	$(MAKE) -C examples/all-sky
+	$(MAKE) -C examples/rfmip-clear-sky
 
 tests:
-	make -C tests                    tests
-	make -C examples/rfmip-clear-sky tests
-	make -C examples/all-sky         tests
+	$(MAKE) -C examples/rfmip-clear-sky $@
+	$(MAKE) -C examples/all-sky         $@
+	$(MAKE) -C tests                    $@
 
 check:
-	make -C tests                    check
-	make -C examples/rfmip-clear-sky check
-	make -C examples/all-sky         check
+	$(MAKE) -C examples/rfmip-clear-sky $@
+	$(MAKE) -C examples/all-sky         $@
+	$(MAKE) -C tests                    $@
 
 docs:
 	@cd doc; ./build_documentation.sh
 
 clean:
-	make -C build clean
-	make -C tests                    clean
-	make -C examples/rfmip-clear-sky clean
-	make -C examples/all-sky         clean
+	$(MAKE) -C build                    $@
+	$(MAKE) -C examples/rfmip-clear-sky $@
+	$(MAKE) -C examples/all-sky         $@
+	$(MAKE) -C tests                    $@
 	rm -rf public

--- a/examples/all-sky/Makefile
+++ b/examples/all-sky/Makefile
@@ -50,10 +50,10 @@ tests:
 	$(RUN_CMD) bash all_tests.sh  
 
 check:
-	python ${RRTMGP_ROOT}/examples/compare-to-reference.py --ref_dir ${RRTMGP_DATA}/examples/all-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/all-sky \
+	$${PYTHON-python} ${RRTMGP_ROOT}/examples/compare-to-reference.py --ref_dir ${RRTMGP_DATA}/examples/all-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/all-sky \
 	       --var lw_flux_up lw_flux_dn sw_flux_up sw_flux_dn sw_flux_dir  \
 	       --file rrtmgp-allsky-lw.nc rrtmgp-allsky-sw.nc
-	python ${RRTMGP_ROOT}/examples/compare-to-reference.py --ref_dir ${RRTMGP_DATA}/examples/all-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/all-sky \
+	$${PYTHON-python} ${RRTMGP_ROOT}/examples/compare-to-reference.py --ref_dir ${RRTMGP_DATA}/examples/all-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/all-sky \
 	       --var lw_flux_up lw_flux_dn sw_flux_up sw_flux_dn sw_flux_dir  \
 	       --file rrtmgp-allsky-lw-no-aerosols.nc rrtmgp-allsky-sw-no-aerosols.nc
 

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -57,7 +57,7 @@ tests: multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc \
 	$(RUN_CMD) ./rrtmgp_rfmip_sw 8 multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
 
 check:
-	python ${RRTMGP_ROOT}/examples/compare-to-reference.py \
+	$${PYTHON-python} ${RRTMGP_ROOT}/examples/compare-to-reference.py \
 	       --ref_dir ${RRTMGP_DATA}/examples/rfmip-clear-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/rfmip-clear-sky \
 	       --var rld rlu rsd rsu --file r??_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -66,7 +66,7 @@ mo_cloud_sampling.o:          $(LIB_DEPS) mo_cloud_sampling.F90
 mo_gas_optics_defs_rrtmgp.o: $(LIB_DEPS) mo_testing_utils.o mo_simple_netcdf.o mo_gas_optics_defs_rrtmgp.F90
 
 mo_load_coefficients.o: $(LIB_DEPS) mo_simple_netcdf.o mo_load_coefficients.F90
-mo_rfmip_io.o.o:        $(LIB_DEPS) mo_simple_netcdf.o mo_rfmip_io.F90
+mo_rfmip_io.o:          $(LIB_DEPS) mo_simple_netcdf.o mo_rfmip_io.F90
 mo_simple_netcdf.o:     $(LIB_DEPS) mo_simple_netcdf.F90
 
 rte_optic_prop_unit_tests.o: $(LIB_DEPS) mo_testing_utils.o rte_optic_prop_unit_tests.F90


### PR DESCRIPTION
- fixes the parallel building in the `tests` directory;
- switches to the [recommended](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html) way of calling `make` recursively;
- gives the users control over the maximum number of `make` processes (generally, `-j` without a value gives worse performance than with the value set to the number of virtual cores on a machine; it's also not very nice towards other users to spawn the unlimited number of processes on a login node);
- makes the `check` recipes honour the `PYTHON` environment variable when locating the Python interpreter (the `python` executable is not generally available and the users might want to set it either to `python3` or to the path to the executable in a virtual environment).

Depends on #265 