### PR TITLE
Get rid of red crosses in the CI reports

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -77,28 +77,51 @@ jobs:
         repository: earth-system-radiation/rrtmgp-data
         path: rrtmgp-data
     #
-    # Build libraries, examples and tests
+    # Build libraries, examples and tests (expect success)
     #
-    - name: Build libraries, examples and tests
+    - name: Build libraries, examples and tests (expect success)
+      id: build-success
+      if: matrix.fortran-compiler != 'ifx' || matrix.rte-kernels != 'accel'
       run: |
         $FC --version
         make libs
         make -C build separate-libs
     #
+    # Build libraries, examples and tests (expect failure)
+    #
+    - name: Build libraries, examples and tests (expect failure)
+      if: steps.build-success.outcome == 'skipped'
+      shell: bash
+      run: |
+        $FC --version
+        make libs 2> >(tee make.err >&2) && {
+          echo "Unexpected success"
+          exit 1
+        } || {
+          grep make.err -e 'Internal compiler error' && {
+            echo "Expected failure"
+          } || {
+            echo "Unexpected failure"
+            exit 1
+          }
+        }
+    #
     # Run examples and tests
     #
     - name: Run examples and tests
+      if: steps.build-success.outcome != 'skipped'
       run: make tests
     #
     # Relax failure thresholds for single precision
     #
     - name: Relax failure threshold for single precision
-      if: matrix.fpmodel == 'SP'
+      if: matrix.fpmodel == 'SP' && steps.build-success.outcome != 'skipped'
       run: echo "FAILURE_THRESHOLD=3.5e-1" >> $GITHUB_ENV
     #
     # Compare the results
     #
     - name: Compare the results
+      if: steps.build-success.outcome != 'skipped'
       run: make check
     #
     # Generate validation plots

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   Containerized-CI:
     runs-on: ubuntu-22.04
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -20,8 +19,6 @@ jobs:
         rte-kernels: [default, accel]
         fpmodel: [DP, SP]
         include:
-        # The tests are not experimental by default:
-        - experimental: false
         # Set flags for Intel Fortran Compiler Classic
         - fortran-compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
@@ -32,7 +29,6 @@ jobs:
         - fortran-compiler: ifx
           rte-kernels: accel
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08 -fiopenmp -fopenmp-targets=spir64
-          experimental: true
         # Set flags for NVIDIA Fortran compiler
         - fortran-compiler: nvfortran
           rte-kernels: default

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -61,7 +61,6 @@ jobs:
   levante:
     runs-on: ubuntu-latest
     needs: levante-init
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,9 +71,6 @@ jobs:
           - nag-cpu-default-SP
           - nag-cpu-accel-DP
           #- nag-cpu-accel-SP
-        include:
-          # The tests are not experimental by default:
-          - experimental: false
     steps:
     #
     # Build, run and check (fetch the log)
@@ -161,16 +157,12 @@ jobs:
   lumi:
     runs-on: ubuntu-latest
     needs: lumi-init
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         config-name:
           - cce-gpu-openacc-DP
           - cce-gpu-openacc-SP
-        include:
-          # The tests are not experimental by default:
-          - experimental: false
     steps:
     #
     # Build, run and check (fetch the log)

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -103,18 +103,31 @@ jobs:
         make libs
         make -C build separate-libs
     #
-    # Run examples and tests
+    # Run examples and tests (expect success)
     #
-    - name: Run examples and tests
+    - name: Run examples and tests (expect success)
+      id: run-success
+      if: matrix.config-name != 'cce-gpu-openmp'
       run: make tests
+    #
+    # Run examples and tests (expect failure)
+    #
+    - name: Run examples and tests (expect failure)
+      if: steps.run-success.outcome == 'skipped'
+      run: |
+        make tests && {
+          echo "Unexpected success"
+          exit 1
+        } || echo "Expected failure"
     #
     # Relax failure thresholds for single precision
     #
     - name: Relax failure threshold for single precision
-      if: matrix.fpmodel == 'SP'
+      if: matrix.fpmodel == 'SP' && steps.run-success.outcome != 'skipped'
       run: echo "FAILURE_THRESHOLD=3.5e-1" >> $GITHUB_ENV
     #
     # Compare the results
     #
     - name: Compare the results
+      if: steps.run-success.outcome != 'skipped'
       run: make check

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -18,15 +18,12 @@ jobs:
     if: github.repository == 'earth-system-radiation/rte-rrtmgp'
     runs-on:
       labels: cscs-ci
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         config-name: [nvidia-gpu-openacc, cce-cpu-icon-production, cce-gpu-openmp]
         fpmodel: [DP, SP]
         include:
-        # The tests are not experimental by default:
-        - experimental: false
         - config-name: nvidia-gpu-openacc
           rte-kernels: accel
           compiler-modules: "PrgEnv-nvidia nvidia craype-accel-nvidia60 cdt-cuda/21.09 !cray-libsci_acc"
@@ -42,7 +39,6 @@ jobs:
           compiler-modules: "PrgEnv-cray craype-accel-nvidia60 cdt-cuda/22.05 cudatoolkit/11.2.0_3.39-2.1__gf93aa1c"
           # OpenMP flags from Nichols Romero (Argonne)
           fcflags: "-hnoacc -homp -O0"
-          experimental: true
     env:
       # Core variables:
       FC: ftn


### PR DESCRIPTION
This should be the first PR in a long time without the annoying red crosses in the CI report.

Several jobs in our CI workflows are known to fail. Currently, we set `continue-on-error: true` for them. This makes at least the workflow status green. However, the red crosses pop up in the PR and commit CI reports. Getting used to them does not look like a good idea to me. One way of dealing with it is to simply remove the jobs. That would be fine with me but I accept the arguments for keeping them.

Job `cce-gpu-openmp` is known to fail at the runtime. This PR changes it so that it is marked green if it does fail at the runtime and is considered as failed otherwise. That is, the job fails the whole `Self-hosted CI` workflow if it does **NOT** fail against the expectations.

The `ifx`+`accel` jobs are known to fail at the build time due to internal compiler errors. This PR changes them so that they are marked green if they fail at the build time with the `Internal compiler error` substring in the build log. In all other cases, the jobs fail the whole `Continuous integration in a box`.