### PR TITLE
Optimize the maximum and minimum operations on the GPU

### DIFF
--- a/rte-frontend/mo_rte_util_array_validation.F90
+++ b/rte-frontend/mo_rte_util_array_validation.F90
@@ -450,7 +450,7 @@ contains
     enddo
     !$omp end target teams
 #else
-    !$acc parallel loop gang vector collapse(2) reduction(min:minValue) reduction(max:maxValue)
+    !$acc parallel loop gang vector collapse(2) reduction(min:minValue) reduction(max:maxValue) copyin(array,mask)
     do j = 1, dim2 
       do i = 1, dim1
           if(mask(i,j)) then 


### PR DESCRIPTION
According to my tests of CAM+RRTMGP on NVIDIA A100 GPU, the OpenACC code runs slowly due to the current implementation of maximum and minimum operations in https://github.com/earth-system-radiation/rte-rrtmgp/blob/develop/rte-frontend/mo_rte_util_array_validation.F90 (see an example below):
```
!$acc kernels copyin(array)
minValue = minval(array)
maxValue = maxval(array)
!$acc end kernels
```
Nsight profiling result shows that the implementation above leads to one threadblock and one thread per threadblock only on the GPU, which basically runs in serial and is not good for GPU performance.

These max and min operations could be revised into a parallelized version that utilizes the GPU resource more efficiently. These changes improve the performance of my new CAM+RRTMGP GPU runs.

I did not test the OpenMP offload code in CAM+RRTMGP though and just revised them by copying the directives from similar existing examples.