### PR TITLE
Skip Gitlab CI for dependabot

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -21,7 +21,8 @@ jobs:
     if: |
       github.repository_owner == 'earth-system-radiation' &&
         ( github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.owner.login == github.repository_owner )
+          ( github.event.pull_request.head.repo.owner.login == github.repository_owner &&
+            github.event.pull_request.user.login != 'dependabot' ))
     runs-on: ubuntu-latest
     outputs:
       ref-name: ${{ steps.g-push-rev.outputs.ref-name }}
@@ -103,7 +104,8 @@ jobs:
     if: |
       github.repository_owner == 'earth-system-radiation' &&
         ( github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.owner.login == github.repository_owner )
+          ( github.event.pull_request.head.repo.owner.login == github.repository_owner &&
+            github.event.pull_request.user.login != 'dependabot' ))
     runs-on: ubuntu-latest
     outputs:
       ref-name: ${{ steps.g-push-rev.outputs.ref-name }}


### PR DESCRIPTION
`GitLab CI` failed for #276 because `dependabot` does not have access to the secrets and we don't want to give it to it. This PR adjusts the rules for `GitLab CI` so that it is skipped for pull requests authored by `dependabot`. Unfortunately, we will learn whether it works only after merging this PR to `develop`.