### PR TITLE
Refactor GitLab CI

### DIFF
--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -1,0 +1,37 @@
+.dp:
+  variables:
+    FPMODEL: DP
+    FAILURE_THRESHOLD: "5.8e-2"
+
+.sp:
+  variables:
+    FPMODEL: SP
+    FAILURE_THRESHOLD: "3.5e-1"
+
+.common:
+  variables:
+    # Make variables:
+    MAKEFLAGS: -j8
+    RRTMGP_ROOT: ${CI_PROJECT_DIR}
+    RRTMGP_DATA: ${CI_PROJECT_DIR}/rrtmgp-data
+    # Convenience variables:
+    RRTMGP_DATA_REPO: https://github.com/earth-system-radiation/rrtmgp-data.git
+    RRTMGP_DATA_TAG:
+  script:
+    #
+    # Build libraries, examples and tests
+    #
+    - ${FC} ${VERSION_FCFLAGS}
+    - make libs
+    #
+    # Check out data
+    #
+    - git clone --depth 1 ${RRTMGP_DATA_TAG:+--branch "${RRTMGP_DATA_TAG}"} "${RRTMGP_DATA_REPO}" "${RRTMGP_DATA}"
+    #
+    # Run examples and tests
+    #
+    - make tests
+    #
+    # Compare the results
+    #
+    - make check

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -5,6 +5,7 @@ workflow:
 include:
   - project: 'anw_dienste/ci-templates'
     file: '.slurm-ci.yml'
+  - local: '.gitlab/common.yml'
 
 variables:
   SCHEDULER_PARAMETERS: >-
@@ -44,17 +45,8 @@ variables:
     NFHOME: /sw/spack-levante/netcdf-fortran-4.5.3-5di6qe
     NCHOME: /sw/spack-levante/netcdf-c-4.8.1-vbnli5
 
-.dp:
-  variables:
-    FPMODEL: DP
-    FAILURE_THRESHOLD: "5.8e-2"
-
-.sp:
-  variables:
-    FPMODEL: SP
-    FAILURE_THRESHOLD: "3.5e-1"
-
-.common:
+.common-levante:
+  extends: .common
   variables:
     PYHOME: /sw/spack-levante/mambaforge-22.9.0-2-Linux-x86_64-kptncg
     # Suppress an irrelevant but annoying error message:
@@ -62,8 +54,6 @@ variables:
     # Make variables:
     FCINCLUDE: -I${NFHOME}/include
     LDFLAGS: -L${NFHOME}/lib -L${NCHOME}/lib
-    RRTMGP_ROOT: ${CI_PROJECT_DIR}
-    RRTMGP_DATA: ${CI_PROJECT_DIR}/rrtmgp-data
   before_script:
     - module purge
     - module load git
@@ -72,30 +62,12 @@ variables:
     - export LD_LIBRARY_PATH="${NFHOME}/lib:${NCHOME}/lib:${LD_LIBRARY_PATH-}"
     # Some tests require a large stack:
     - ulimit -s unlimited
-  script:
-    #
-    # Build libraries, examples and tests
-    #
-    - ${FC} ${VERSION_FCFLAGS}
-    - make -j8 libs
-    #
-    # Check out data
-    #
-    - git clone --depth 1 https://github.com/earth-system-radiation/rrtmgp-data.git "${RRTMGP_DATA}"
-    #
-    # Run examples and tests
-    #
-    - make -j8 tests
-    #
-    # Compare the results
-    #
-    - make -j8 check
 
 .nvhpc-gpu-openacc:
   extends:
     - .gpu
     - .nvhpc
-    - .common
+    - .common-levante
   variables:
     # Compiler flags used for ICON model:
     FCFLAGS: -g -O2 -Mrecursive -Mallocatable=03 -Mstack_arrays -Minfo=accel,inline -acc=gpu,verystrict -gpu=cc80,cuda11.7 -DRTE_USE_${FPMODEL}
@@ -105,7 +77,7 @@ variables:
   extends:
     - .cpu
     - .nag
-    - .common
+    - .common-levante
   variables:
     # Compiler flags used for ICON model:
     FCFLAGS: -Wc=/sw/spack-levante/gcc-11.2.0-bcn7mb/bin/gcc -f2008 -colour -w=uep -g -gline -O0 -float-store -nan -Wc,-g -Wc,-pipe -Wc,--param,max-vartrack-size=200000000 -Wc,-mno-fma -C=all -DRTE_USE_CBOOL -DRTE_USE_${FPMODEL}
@@ -130,11 +102,6 @@ nvhpc-gpu-openacc-SP:
     - .sp
     - .nvhpc-gpu-openacc
 
-#nag-cpu-default-DP:
-#  extends:
-#    - .dp
-#    - .nag-cpu-default
-
 nag-cpu-default-SP:
   extends:
     - .sp
@@ -144,8 +111,3 @@ nag-cpu-accel-DP:
   extends:
     - .dp
     - .nag-cpu-accel
-
-#nag-cpu-accel-SP:
-#  extends:
-#    - .sp
-#    - .nag-cpu-accel

--- a/.gitlab/lumi.yml
+++ b/.gitlab/lumi.yml
@@ -2,7 +2,10 @@ workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "api"
 
-default:
+include:
+  - local: '.gitlab/common.yml'
+
+.default:
   tags:
     - lumi
 
@@ -18,12 +21,14 @@ variables:
   EXTRA_SCHEDULER_PARAMETERS:
 
 .gpu:
+  extends: .default
   variables:
     EXTRA_SCHEDULER_PARAMETERS: >-
       --partition=dev-g
       --gpus=1
 
 .cpu:
+  extends: .default
   variables:
     EXTRA_SCHEDULER_PARAMETERS: >-
       --partition=debug
@@ -36,20 +41,10 @@ variables:
     VERSION_FCFLAGS: -V
     COMPILER_MODULES: PrgEnv-cray cce/16.0.1 craype-x86-milan
 
-.dp:
-  variables:
-    FPMODEL: DP
-    FAILURE_THRESHOLD: "5.8e-2"
-
-.sp:
-  variables:
-    FPMODEL: SP
-    FAILURE_THRESHOLD: "3.5e-1"
-
 #
 # Set up Python virtual environment
 #
-.python-common:
+.python-common-lumi:
   variables:
     PYHOME: ${CI_PROJECT_DIR}/python-venv
     FF_USE_FASTZIP: 1
@@ -57,7 +52,7 @@ variables:
 setup-python:
   extends:
     - .cpu
-    - .python-common
+    - .python-common-lumi
   script:
     - test ! -d "${PYHOME}" || exit 0
     - module load cray-python
@@ -74,43 +69,23 @@ setup-python:
       - ${PYHOME}
     expire_in: 60 minutes
 
-.common:
-  extends: .python-common
+.common-lumi:
+  extends:
+    - .python-common-lumi
+    - .common
   needs:
     - setup-python
-  variables:
-    # Make variables:
-    RRTMGP_ROOT: ${CI_PROJECT_DIR}
-    RRTMGP_DATA: ${CI_PROJECT_DIR}/rrtmgp-data
   before_script:
     - module --force purge
     - module load ${COMPILER_MODULES} ${EXTRA_COMPILER_MODULES} cray-hdf5 cray-netcdf
     # Extend the existing environment variables:
     - export PATH="${PYHOME}/bin:${PATH}"
-  script:
-    #
-    # Build libraries, examples and tests
-    #
-    - ${FC} ${VERSION_FCFLAGS}
-    - make -j8 libs
-    #
-    # Check out data
-    #
-    - git clone --depth 1 https://github.com/earth-system-radiation/rrtmgp-data.git "${RRTMGP_DATA}"
-    #
-    # Run examples and tests
-    #
-    - make -j8 tests
-    #
-    # Compare the results
-    #
-    - make -j8 check
 
 .cce-gpu-openacc:
   extends:
     - .gpu
     - .cce
-    - .common
+    - .common-lumi
   variables:
     # Compiler flags used for ICON model:
     FCFLAGS: -hacc -hadd_paren -Ktrap=divz,ovf,inv -hflex_mp=intolerant -hfp1 -g -DRTE_USE_${FPMODEL}


### PR DESCRIPTION
This moves common parts of `levante.yml` and `lumi.yml` to `common.yml`, which should make the maintenance easier.