### PR TITLE
Facilitate per-band Tsfc Jacobians by including in ty_fluxes

### DIFF
--- a/extensions/mo_compute_bc.F90
+++ b/extensions/mo_compute_bc.F90
@@ -39,7 +39,7 @@ module mo_compute_bc
   ! Extend ty_fluxes to report spectrally-resolved downwelling flux at a single layer
   !
   type, extends(ty_fluxes) :: ty_fluxes_1lev
-    real(wp), dimension(:,:), pointer :: gpt_flux_dn => NULL()    ! (ncol, nlev, nband)
+    real(wp), dimension(:,:), pointer :: gpt_flux_dn => NULL()    ! (ncol, nlev, ngpt)
   contains
     procedure :: reduce => reduce_1lev
     procedure :: are_desired => are_desired_1lev
@@ -197,14 +197,19 @@ contains
     endif
   end function
   ! --------------------------------------------------------------------------------------
-  function reduce_1lev(this, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, gpt_flux_dn_dir) result(error_msg)
+  function reduce_1lev(this, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, &
+      gpt_flux_dn_dir, gpt_flux_up_Jac) result(error_msg)
     class(ty_fluxes_1lev),             intent(inout) :: this
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
     logical,                           intent(in   ) :: top_at_1
     real(kind=wp), dimension(:,:,:), optional, &
-                                       intent(in   ) :: gpt_flux_dn_dir! Direct flux down
+                                       intent(in   ) :: gpt_flux_dn_dir ! Direct flux down
+                                                                        ! [W/m2](ncol, nlay+1, ngpt)
+    real(kind=wp), dimension(:,:,:), optional, &
+                                       intent(in   ) :: gpt_flux_up_Jac ! Surface temperature flux Jacobian
+                                                                        ! [W/m2/K](ncol, nlay+1, ngpt)
     character(len=128)                               :: error_msg
     ! ------
     integer :: ncol, nlev, ngpt, bottom_lev

--- a/extensions/mo_fluxes_bygpoint.F90
+++ b/extensions/mo_fluxes_bygpoint.F90
@@ -30,20 +30,25 @@ module mo_fluxes_bygpoint
                                            gpt_flux_dn => NULL()    ! (ncol, nlev, nband)
     real(wp), dimension(:,:,:), pointer :: gpt_flux_net => NULL()   ! Net (down - up)
     real(wp), dimension(:,:,:), pointer :: gpt_flux_dn_dir => NULL() ! Direct flux down
+    real(wp), dimension(:,:,:), pointer :: gpt_flux_up_Jac => NULL() ! Sfc Temp Jacobian
   contains
     procedure :: reduce => reduce_bygpoint
     procedure :: are_desired => are_desired_bygpoint
   end type ty_fluxes_bygpoint
 contains
   ! --------------------------------------------------------------------------------------
-  function reduce_bygpoint(this, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, gpt_flux_dn_dir) result(error_msg)
+  function reduce_bygpoint(this, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, &
+      gpt_flux_dn_dir, gpt_flux_up_Jac) result(error_msg)
     class(ty_fluxes_bygpoint),         intent(inout) :: this
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
     logical,                           intent(in   ) :: top_at_1
     real(kind=wp), dimension(:,:,:), optional, &
-                                       intent(in   ) :: gpt_flux_dn_dir! Direct flux down
+                                       intent(in   ) :: gpt_flux_dn_dir ! Direct flux down [W/m2](ncol, nlay+1, ngpt)
+    real(kind=wp), dimension(:,:,:), optional, &
+                                       intent(in   ) :: gpt_flux_up_Jac ! Surface temperature flux Jacobian
+                                                                        ! [W/m2/K](ncol, nlay+1, ngpt)
     character(len=128)                               :: error_msg
     ! ------
     integer :: ncol, nlev, ngpt, nbnd
@@ -55,30 +60,37 @@ contains
 
     if(associated(this%gpt_flux_up)) then
       if(.not. extents_are(this%gpt_flux_up, ncol, nlev, ngpt)) then
-        error_msg = "reduce: gpt_flux_up array incorrectly sized (can't compute net flux either)"
+        error_msg = "reduce: gpt_flux_up array incorrectly sized"
       else
         this%gpt_flux_up(:,:,:) = gpt_flux_up(:,:,:)
       end if
     end if
     if(associated(this%gpt_flux_dn)) then
       if(.not. extents_are(this%gpt_flux_dn, ncol, nlev, ngpt)) then
-        error_msg = "reduce: gpt_flux_dn array incorrectly sized (can't compute net flux either)"
+        error_msg = "reduce: gpt_flux_dn array incorrectly sized"
       else
         this%gpt_flux_dn(:,:,:) = gpt_flux_dn(:,:,:)
       end if
     end if
     if(associated(this%gpt_flux_net)) then
       if(.not. extents_are(this%gpt_flux_net, ncol, nlev, ngpt)) then
-        error_msg = "reduce: gpt_flux_net array incorrectly sized (can't compute net flux either)"
+        error_msg = "reduce: gpt_flux_net array incorrectly sized"
       else
         this%gpt_flux_net(:,:,:) = gpt_flux_dn(:,:,:) - gpt_flux_up(:,:,:)
       end if
     end if
     if(associated(this%gpt_flux_dn_dir)) then
       if(.not. extents_are(this%gpt_flux_dn_dir, ncol, nlev, ngpt)) then
-        error_msg = "reduce: gpt_flux_dn_dir array incorrectly sized (can't compute net flux either)"
+        error_msg = "reduce: gpt_flux_dn_dir array incorrectly sized"
       else if(present(gpt_flux_dn_dir)) then
         this%gpt_flux_dn_dir(:,:,:) = gpt_flux_dn_dir(:,:,:)
+      end if
+    end if
+    if(associated(this%gpt_flux_up_Jac)) then
+      if(.not. extents_are(this%gpt_flux_up_Jac, ncol, nlev, ngpt)) then
+        error_msg = "reduce: gpt_flux_up_Jac array incorrectly sized"
+      else if(present(gpt_flux_up_Jac)) then
+        this%gpt_flux_up_Jac(:,:,:) = gpt_flux_up_Jac(:,:,:)
       end if
     end if
   end function reduce_bygpoint
@@ -94,6 +106,7 @@ contains
       are_desired_bygpoint = any([associated(this%gpt_flux_up),     &
                                   associated(this%gpt_flux_dn),     &
                                   associated(this%gpt_flux_dn_dir), &
+                                  associated(this%gpt_flux_up_Jac), &
                                   associated(this%gpt_flux_net)])
     end function are_desired_bygpoint
 


### PR DESCRIPTION
For review by @RobertPincus ... Please see @mathomp4 for git questions:
The motivation is to add surface temperature Jacobians by band. The proposed solution was to add the Jacobians to ty_fluxes and use the same reduce infrastructure to make them available per band, per g-point, or however. It also makes the call to rte_lw() a bit cleaner since the Jacobian no longer appears as an optional item in that call.
I am not wedded to this solution .... just for your review and some discussion. 
Thanks, Peter.