### PR TITLE
Set default variables in the makefiles

### DIFF
--- a/examples/all-sky/Makefile
+++ b/examples/all-sky/Makefile
@@ -2,6 +2,7 @@
 #
 # Location of RTE+RRTMGP libraries, module files.
 #
+RRTMGP_ROOT ?= ../..
 RRTMGP_BUILD = $(RRTMGP_ROOT)/build
 #
 # RRTMGP library, module files

--- a/examples/all-sky/Makefile
+++ b/examples/all-sky/Makefile
@@ -16,7 +16,7 @@ FCINCLUDE += -I$(RRTMGP_BUILD)
 
 # netcdf C and Fortran libraries have to be in the search path or added via environment variable LDFLAGS e.g. 
 #LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
-LIBS      += -lnetcdff -lnetcdf
+LIBS      += -lnetcdff
 
 VPATH = ../:$(RRTMGP_ROOT)/rrtmgp-frontend # Needed for cloud_optics and aerosol_optics
 

--- a/examples/all-sky/Makefile
+++ b/examples/all-sky/Makefile
@@ -48,6 +48,11 @@ mo_load_coefficients.o:         mo_simple_netcdf.o                              
 mo_load_cloud_coefficients.o:   mo_simple_netcdf.o mo_cloud_optics_rrtmgp.o         mo_load_cloud_coefficients.F90
 mo_load_aerosol_coefficients.o: mo_simple_netcdf.o mo_aerosol_optics_rrtmgp_merra.o mo_load_aerosol_coefficients.F90
 
+# The default location of the input data:
+RRTMGP_DATA ?= $(RRTMGP_ROOT)/rrtmgp-data
+# Make it available to the scripts:
+export RRTMGP_DATA
+
 tests: rrtmgp_allsky
 	$(RUN_CMD) bash all_tests.sh  
 

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -16,7 +16,7 @@ FCINCLUDE += -I$(RRTMGP_BUILD)
 
 # netcdf C and Fortran libraries have to be in the search path or added via environment variable LDFLAGS e.g. 
 #LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
-LIBS      += -lnetcdff -lnetcdf
+LIBS      += -lnetcdff
 
 VPATH = ../
 

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -2,6 +2,7 @@
 #
 # Location of RTE+RRTMGP libraries, module files.
 #
+RRTMGP_ROOT ?= ../..
 RRTMGP_BUILD = $(RRTMGP_ROOT)/build
 #
 # RRTMGP library, module files

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -61,6 +61,11 @@ tests: rrtmgp_rfmip_lw rrtmgp_rfmip_sw \
 	$(RUN_CMD) ./rrtmgp_rfmip_lw 8 multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
 	$(RUN_CMD) ./rrtmgp_rfmip_sw 8 multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
 
+# The default failure threshold:
+FAILURE_THRESHOLD ?= 7.e-4
+# Make it available to the scripts:
+export FAILURE_THRESHOLD
+
 check:
 	$${PYTHON-python} ${RRTMGP_ROOT}/examples/compare-to-reference.py \
 	       --ref_dir ${RRTMGP_DATA}/examples/rfmip-clear-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/rfmip-clear-sky \

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -51,6 +51,9 @@ mo_rfmip_io.o:          mo_rfmip_io.F90          mo_simple_netcdf.o
 
 mo_load_coefficients.o: mo_load_coefficients.F90 mo_simple_netcdf.o
 
+# The default location of the input data:
+RRTMGP_DATA ?= $(RRTMGP_ROOT)/rrtmgp-data
+
 tests: rrtmgp_rfmip_lw rrtmgp_rfmip_sw \
        multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc \
        rld_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc rlu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,7 @@
 #
 # Location of RTE+RRTMGP libraries, module files.
 #
+RRTMGP_ROOT ?= ..
 RRTMGP_BUILD = $(RRTMGP_ROOT)/build
 #
 # RRTMGP library, module files

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ FCINCLUDE += -I$(RRTMGP_BUILD)
 
 # netcdf C and Fortran libraries have to be in the search path or added via environment variable LDFLAGS e.g. 
 #LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
-LIBS      += -lnetcdff -lnetcdf
+LIBS      += -lnetcdff
 
 VPATH  = $(RRTMGP_ROOT)/examples:$(RRTMGP_ROOT)/examples/rfmip-clear-sky:$(RRTMGP_ROOT)/examples/all-sky
 VPATH += $(RRTMGP_ROOT)/rrtmgp-frontend:$(RRTMGP_ROOT)/extensions:$(RRTMGP_ROOT)/:$(RRTMGP_ROOT)/extensions/solar_variability

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -79,6 +79,11 @@ rte_sw_solver_unit_tests.o: $(LIB_DEPS) mo_testing_utils.o rte_sw_solver_unit_te
 rte_sw_solver_unit_tests  : $(LIB_DEPS) mo_testing_utils.o rte_sw_solver_unit_tests.o
 
 
+# The default location of the input data:
+RRTMGP_DATA ?= $(RRTMGP_ROOT)/rrtmgp-data
+# Make it available to the scripts:
+export RRTMGP_DATA
+
 .PHONY: tests
 tests: check_variants check_equivalence test_zenith_angle_spherical_correction rte_sw_solver_unit_tests rte_optic_prop_unit_tests rte_lw_solver_unit_tests
 	cp ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc ./test_atmospheres.nc


### PR DESCRIPTION
This sets the default values for several variables that are important for building and testing. The values can still be overridden with the environment variables.

Hopefully, these changes make it easier for the new users to build the libraries and run the tests for the first time.