### PR TITLE
ci: enable testing on Windows with GCC

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,30 +9,64 @@ on:
     - documentation
   workflow_dispatch:
 
-defaults:
-  run:
-    # Enable Conda environment by using the login shell:
-    shell: bash -leo pipefail {0}
 
 jobs:
   CI:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
+        os: [ubuntu-latest, windows-latest]
         fpmodel: [DP, SP]
+        toolchain:
+          - {compiler: gcc, version: 10}
+          - {compiler: gcc, version: 11}
+          - {compiler: gcc, version: 12}
+        include:
+          - os: ubuntu-latest
+            shell: bash -leo pipefail {0}
+            make: make
+          - os: windows-latest
+            shell: "msys2 -leo pipefail {0}"
+            make: mingw32-make.exe
+        exclude:
+          - os: windows-latest
+            toolchain:
+              compiler: gcc
+              version: 12
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+
     env:
       # Core variables:
-      FC: ${{ matrix.fortran-compiler }}
       FCFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -fmodule-private -fimplicit-none -finit-real=nan -g -DRTE_USE_CBOOL -DRTE_USE_${{ matrix.fpmodel }}"
       # Make variables:
-      FCINCLUDE: -I/usr/include
       RRTMGP_ROOT: ${{ github.workspace }}
       RRTMGP_DATA: ${{ github.workspace }}/rrtmgp-data
       RUN_CMD:
       FAILURE_THRESHOLD: 7.e-4
     steps:
+    #
+    # Setup MSYS2 on Windows
+    #
+    - if: runner.os == 'Windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        path-type: inherit
+        install: >-
+          mingw-w64-x86_64-make
+          mingw-w64-x86_64-netcdf-fortran
+    #
+    # Setup Fortran compiler
+    #
+    - uses: fortran-lang/setup-fortran@v1.6.1
+      id: setup-fortran
+      with:
+        compiler: ${{ matrix.toolchain.compiler }}
+        version: ${{ matrix.toolchain.version }}
     #
     # Relax failure thresholds for single precision
     #
@@ -54,23 +88,14 @@ jobs:
         path: rrtmgp-data
         ref: v1.8.1
     #
-    # Synchronize the package index
-    #
-    - name: Synchronize the package index
-      run: sudo apt-get update
-    #
-    # Install NetCDF-Fortran (compatible with all compilers)
-    #
-    - name: Install NetCDF-Fortran
-      run: sudo apt-get install libnetcdff-dev
-    #
     # Cache Conda packages
     #
     - name: Cache Conda packages
       uses: actions/cache@v4
       with:
         path: ~/conda_pkgs_dir
-        key: conda-pkgs
+        key:
+          ${{ runner.os }}-conda-${{ hashFiles('environment-ci.yml') }}
     #
     # Set up Conda
     #
@@ -78,26 +103,52 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
-        activate-environment: rte_rrtmgp_test
-        environment-file: environment-noplots.yml
-        python-version: 3.11
+        activate-environment: rte_rrtmgp_ci
+        environment-file: environment-ci.yml
         auto-activate-base: false
+        use-mamba: true
         # Use the cache properly:
         use-only-tar-bz2: true
+    #
+    # Install NetCDF-Fortran
+    #
+    - name: Install NetCDF-Fortran via Conda
+      if: runner.os == 'Linux'
+      run: conda install -y -c conda-forge netcdf-fortran
+    #
+    # Setup Linux environment variables
+    #
+    - name: Setup env variables - Linux
+      if: runner.os == 'Linux'
+      run: |
+        echo FCINCLUDE=-I ${CONDA_PREFIX}/include >> $GITHUB_ENV
+        echo LDFLAGS=-L ${CONDA_PREFIX}/lib >> $GITHUB_ENV
+        echo LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH} >> $GITHUB_ENV
+    #
+    # Setup Windows environment variables
+    #
+    - name: Setup env variables - Windows
+      if: runner.os == 'Windows'
+      run: |
+        echo FCINCLUDE="-I/mingw64/include" >> $GITHUB_ENV
+        echo LDFLAGS="-L/mingw64/lib" >> $GITHUB_ENV
+        echo LD_LIBRARY_PATH="/mingw64/lib:/mingw64/bin:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
     #
     # Build libraries, examples and tests
     #
     - name: Build libraries
       run: |
         $FC --version
-        make -j4 libs
+        ${{ matrix.make }} -j4 libs
     #
     # Run examples and tests
     #
     - name: Build and run examples and tests
-      run: make -j4 tests
+      run: |
+        ${{ matrix.make }} -j4 tests
     #
     # Compare the results
     #
     - name: Compare the results
-      run: make -j4 check
+      run: |
+        ${{ matrix.make }} -j4 check

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -1,0 +1,11 @@
+name: rte_rrtmgp_ci
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.11
+  - numpy
+  - netcdf4
+  - xarray
+  - dask
+  - numpy

--- a/examples/all-sky/Makefile
+++ b/examples/all-sky/Makefile
@@ -57,10 +57,10 @@ tests: rrtmgp_allsky
 	$(RUN_CMD) bash all_tests.sh  
 
 check:
-	$${PYTHON-python} ${RRTMGP_ROOT}/examples/compare-to-reference.py --ref_dir ${RRTMGP_DATA}/examples/all-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/all-sky \
+	$${PYTHON-python} "$(RRTMGP_ROOT)/examples/compare-to-reference.py" --ref_dir "$(RRTMGP_DATA)/examples/all-sky/reference" --tst_dir "$(RRTMGP_ROOT)/examples/all-sky" \
 	       --var lw_flux_up lw_flux_dn sw_flux_up sw_flux_dn sw_flux_dir  \
 	       --file rrtmgp-allsky-lw.nc rrtmgp-allsky-sw.nc
-	$${PYTHON-python} ${RRTMGP_ROOT}/examples/compare-to-reference.py --ref_dir ${RRTMGP_DATA}/examples/all-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/all-sky \
+	$${PYTHON-python} "$(RRTMGP_ROOT)/examples/compare-to-reference.py" --ref_dir "$(RRTMGP_DATA)/examples/all-sky/reference" --tst_dir "$(RRTMGP_ROOT)/examples/all-sky" \
 	       --var lw_flux_up lw_flux_dn sw_flux_up sw_flux_dn sw_flux_dir  \
 	       --file rrtmgp-allsky-lw-no-aerosols.nc rrtmgp-allsky-sw-no-aerosols.nc
 

--- a/examples/all-sky/all_tests.sh
+++ b/examples/all-sky/all_tests.sh
@@ -1,4 +1,10 @@
 set -eux
+if [[ $(uname) == *"NT"* ]]; then
+    # Rename files ending with .exe to the same name without the extension
+    for file in *.exe; do
+        mv "$file" "${file%.exe}"
+    done
+fi
 ./rrtmgp_allsky 24 72 1 rrtmgp-allsky-lw.nc \
 	    ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc ${RRTMGP_DATA}/rrtmgp-aerosols-merra-lw.nc 
 ./rrtmgp_allsky 24 72 1 rrtmgp-allsky-sw.nc \

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -67,9 +67,14 @@ FAILURE_THRESHOLD ?= 7.e-4
 export FAILURE_THRESHOLD
 
 check:
-	$${PYTHON-python} ${RRTMGP_ROOT}/examples/compare-to-reference.py \
-	       --ref_dir ${RRTMGP_DATA}/examples/rfmip-clear-sky/reference --tst_dir ${RRTMGP_ROOT}/examples/rfmip-clear-sky \
-	       --var rld rlu rsd rsu --file r??_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
+	$${PYTHON-python} "$(RRTMGP_ROOT)/examples/compare-to-reference.py" \
+	       --ref_dir "$(RRTMGP_DATA)/examples/rfmip-clear-sky/reference" \
+		   --tst_dir "$(RRTMGP_ROOT)/examples/rfmip-clear-sky" \
+	       --var rld rlu rsd rsu \
+		   --file_names rld_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc \
+		   				rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc \
+						rlu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc \
+						rsu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
 
 clean:
 	-rm rrtmgp_rfmip_sw rrtmgp_rfmip_lw *.o *.mod *.optrpt *.nc

--- a/tests/all_tests.sh
+++ b/tests/all_tests.sh
@@ -1,4 +1,10 @@
 set -eux
+if [[ $(uname) == *"NT"* ]]; then
+    # Rename files ending with .exe to the same name without the extension
+    for file in *.exe; do
+        mv "$file" "${file%.exe}"
+    done
+fi
 ./rte_optic_prop_unit_tests
 ./rte_lw_solver_unit_tests
 ./rte_sw_solver_unit_tests


### PR DESCRIPTION
- Compilers are installed via the GA fortran-setup (choco in the backend)
- Version of NetCDF via APT has been replaced with conda, where possible
  and packman on Windows
- Consequently, include and link directories need to be setup at runtime
  for variable expansion to occur
- In the Makefiles changes have been made to properly handle variable expansions
  and bash-like regular expressions

## Additional Notes

- GCC 12+ on the Windows runners causes some rather weird behaviour that I was unable to recreate locally with the same compiler version on a Windows 10 VM. I tried a fair bit of time trying to get to the bottom of it but I am not sure what is going on.
- `environment-noplots.yml` is not used anymore so if you have no use for it I could delete it.
- On Windows I install NetCDF via msys because the conda-forge version has been compiled GFortran 5 and hence its ABI is incompatible **and** the the conda-forge package is not available whilst `use-only-tar-bz2` is `true`.
- I believe the Windows cache for Anaconda is not setup correctly.
- It would be great if we could cache the compilers, especially for Windows.
- You could probably test the Intel compilers in the same Workflow.
- I would suggest enabling backtraces and increasing compile/runtime checks with GCC specifically `-fcheck=all -finit-real=snan -finit-integer=-999999 -finit-character=0 -ffpe-trap=invalid,zero,overflow -fbacktrace`. The `-ffpe-trap=...` options cause for a segfault which I am guessing are indicative of a bug.