### PR TITLE
Fixes for CI

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -25,6 +25,7 @@ jobs:
             github.event.pull_request.user.login != 'dependabot[bot]' ))
     runs-on: ubuntu-latest
     outputs:
+      ref-type: ${{ steps.g-push-rev.outputs.ref-type }}
       ref-name: ${{ steps.g-push-rev.outputs.ref-name }}
       pipeline-id: ${{ steps.gl-trigger-pipeline.outputs.pipeline-id }}
     steps:
@@ -94,7 +95,7 @@ jobs:
       with:
         remote-url: ${{ vars.DKRZ_GITLAB_SERVER }}/${{ vars.DKRZ_GITLAB_PROJECT }}.git
         password: ${{ secrets.DKRZ_GITLAB_TOKEN }}
-        ref-type: tag
+        ref-type: ${{ needs.levante-init.outputs.ref-type }}
         ref-name: ${{ needs.levante-init.outputs.ref-name }}
         force: true
   #
@@ -108,6 +109,7 @@ jobs:
             github.event.pull_request.user.login != 'dependabot[bot]' ))
     runs-on: ubuntu-latest
     outputs:
+      ref-type: ${{ steps.g-push-rev.outputs.ref-type }}
       ref-name: ${{ steps.g-push-rev.outputs.ref-name }}
       pipeline-id: ${{ steps.gl-create-pipeline.outputs.pipeline-id }}
     steps:
@@ -193,6 +195,6 @@ jobs:
         server-url: ${{ vars.GITLAB_SERVER }}
         project-name: ${{ vars.GITLAB_PROJECT }}
         token: ${{ secrets.GITLAB_TOKEN }}
-        ref-type: branch
+        ref-type: ${{ needs.lumi-init.outputs.ref-type }}
         ref-name: ${{ needs.lumi-init.outputs.ref-name }}
         force: true

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -130,8 +130,7 @@ jobs:
         rev-id: ${{ github.sha }}
         rev-signing-format: ssh
         rev-signing-key: ${{ secrets.GITLAB_SIGNING_KEY }}
-        ref-type: tag
-        ref-message: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ref-type: branch
         force-push: true
     #
     # Create GitLab CI/CD Pipeline
@@ -194,6 +193,6 @@ jobs:
         server-url: ${{ vars.GITLAB_SERVER }}
         project-name: ${{ vars.GITLAB_PROJECT }}
         token: ${{ secrets.GITLAB_TOKEN }}
-        ref-type: tag
+        ref-type: branch
         ref-name: ${{ needs.lumi-init.outputs.ref-name }}
         force: true

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -190,6 +190,7 @@ jobs:
         project-name: ${{ vars.GITLAB_PROJECT }}
         token: ${{ secrets.GITLAB_TOKEN }}
         pipeline-id: ${{ needs.lumi-init.outputs.pipeline-id }}
+        force: true
     - uses: "skosukhin/git-ci-hub-lab/gl-delete-ref@v1"
       with:
         server-url: ${{ vars.GITLAB_SERVER }}

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     shell: bash
 
+# A workaround for the old runtime:
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   CI:
     if: github.repository == 'earth-system-radiation/rte-rrtmgp'


### PR DESCRIPTION
1. Work around the issue with the signature checker on Lumi: push revisions as branches and not as tags.
2. Reduce code duplication in the CI description.
3. Avoid failing the clean-up when removing a GitLab pipeline that has not been created yet.
4. Work around the issue with the old node runtime on Daint (see https://github.com/actions/checkout/issues/1809).