### PR TITLE
Disable Lumi CI

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -103,6 +103,7 @@ jobs:
   #
   lumi-init:
     if: |
+      false && 
       github.repository_owner == 'earth-system-radiation' &&
         ( github.event_name != 'pull_request' ||
           ( github.event.pull_request.head.repo.owner.login == github.repository_owner &&


### PR DESCRIPTION
Based on problems with the Lumi software stack we will temporarily disable CI on that host. To be revisited after @skosukhin  reports back from a hackathon the week of Nov 10. 