### PR TITLE
Fix gas optics interpolation

### DIFF
--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -90,6 +90,7 @@ contains
     real(wp) :: press_ref_trop
     real(wp) :: temp_ref_delta_inv
     real(wp) :: press_ref_log_1
+    real(wp) :: press_ref_log_delta_inv
     ! -----------------
     ! local indexes
     integer :: icol, ilay, iflav, igases_1, igases_2, itropo, itemp, jtemp_
@@ -97,6 +98,7 @@ contains
     press_ref_trop = exp(press_ref_trop_log)
     temp_ref_delta_inv = 1.0_wp / temp_ref_delta
     press_ref_log_1 = press_ref_log(1)
+    press_ref_log_delta_inv = 1.0_wp / press_ref_log_delta
     do ilay = 1, nlay
       do icol = 1, ncol
         ! index and factor for temperature interpolation
@@ -105,7 +107,7 @@ contains
         ftemp(icol,ilay) = (tlay(icol,ilay) - temp_ref(jtemp_)) * temp_ref_delta_inv
 
         ! index and factor for pressure interpolation
-        locpress = 1._wp + (log(play(icol,ilay)) - press_ref_log_1) / press_ref_log_delta
+        locpress = 1._wp + (log(play(icol,ilay)) - press_ref_log_1) * press_ref_log_delta_inv
         jpress(icol,ilay) = min(npres-1, max(1, int(locpress)))
         fpress(icol,ilay) = locpress - float(jpress(icol,ilay))
 

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -149,7 +149,7 @@ contains
             else
               eta = 0.5_wp
             endif
-            loceta = eta * float(neta-1)
+            loceta = eta * real(neta-1, wp)
             jeta(itemp,icol,ilay,iflav) = min(int(loceta)+1, neta-1)
             feta = loceta - aint(loceta)
             ! compute interpolation fractions needed for minor species

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -91,6 +91,7 @@ contains
     real(wp) :: temp_ref_delta_inv
     real(wp) :: press_ref_log_1
     real(wp) :: press_ref_log_delta_inv
+    real(wp) :: jpress_aint
     ! -----------------
     ! local indexes
     integer :: icol, ilay, iflav, igases_1, igases_2, itropo, itemp, jtemp_
@@ -108,8 +109,9 @@ contains
 
         ! index and factor for pressure interpolation
         locpress = 1._wp + (log(play(icol,ilay)) - press_ref_log_1) * press_ref_log_delta_inv
-        jpress(icol,ilay) = min(npres-1, max(1, int(locpress)))
-        fpress(icol,ilay) = locpress - float(jpress(icol,ilay))
+        jpress_aint = min(real(npres-1, wp), max(1.0_wp, aint(locpress)))
+        jpress(icol,ilay) = int(jpress_aint)
+        fpress(icol,ilay) = locpress - jpress_aint
 
         ! determine if in lower or upper part of atmosphere
         tropo(icol,ilay) = play(icol,ilay) > press_ref_trop

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -88,17 +88,19 @@ contains
     real(wp) :: loceta         ! needed to find location in eta grid
     real(wp) :: ftemp_term
     real(wp) :: press_ref_trop
+    real(wp) :: temp_ref_delta_inv
     ! -----------------
     ! local indexes
     integer :: icol, ilay, iflav, igases_1, igases_2, itropo, itemp, jtemp_
 
     press_ref_trop = exp(press_ref_trop_log)
+    temp_ref_delta_inv = 1.0_wp / temp_ref_delta
     do ilay = 1, nlay
       do icol = 1, ncol
         ! index and factor for temperature interpolation
-        jtemp_ = int((tlay(icol,ilay) - (temp_ref_min - temp_ref_delta)) / temp_ref_delta)
+        jtemp_ = INT((tlay(icol,ilay) - (temp_ref_min - temp_ref_delta)) * temp_ref_delta_inv)
         jtemp(icol,ilay) = min(ntemp - 1, max(1, jtemp_)) ! limit the index range
-        ftemp(icol,ilay) = (tlay(icol,ilay) - temp_ref(jtemp_)) / temp_ref_delta
+        ftemp(icol,ilay) = (tlay(icol,ilay) - temp_ref(jtemp_)) * temp_ref_delta_inv
 
         ! index and factor for pressure interpolation
         locpress = 1._wp + (log(play(icol,ilay)) - press_ref_log(1)) / press_ref_log_delta

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -89,12 +89,14 @@ contains
     real(wp) :: ftemp_term
     real(wp) :: press_ref_trop
     real(wp) :: temp_ref_delta_inv
+    real(wp) :: press_ref_log_1
     ! -----------------
     ! local indexes
     integer :: icol, ilay, iflav, igases_1, igases_2, itropo, itemp, jtemp_
 
     press_ref_trop = exp(press_ref_trop_log)
     temp_ref_delta_inv = 1.0_wp / temp_ref_delta
+    press_ref_log_1 = press_ref_log(1)
     do ilay = 1, nlay
       do icol = 1, ncol
         ! index and factor for temperature interpolation
@@ -103,7 +105,7 @@ contains
         ftemp(icol,ilay) = (tlay(icol,ilay) - temp_ref(jtemp_)) * temp_ref_delta_inv
 
         ! index and factor for pressure interpolation
-        locpress = 1._wp + (log(play(icol,ilay)) - press_ref_log(1)) / press_ref_log_delta
+        locpress = 1._wp + (log(play(icol,ilay)) - press_ref_log_1) / press_ref_log_delta
         jpress(icol,ilay) = min(npres-1, max(1, int(locpress)))
         fpress(icol,ilay) = locpress - float(jpress(icol,ilay))
 

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -87,10 +87,12 @@ contains
     real(wp) :: eta, feta      ! binary_species_parameter, interpolation variable for eta
     real(wp) :: loceta         ! needed to find location in eta grid
     real(wp) :: ftemp_term
+    real(wp) :: press_ref_trop
     ! -----------------
     ! local indexes
     integer :: icol, ilay, iflav, igases_1, igases_2, itropo, itemp, jtemp_
 
+    press_ref_trop = exp(press_ref_trop_log)
     do ilay = 1, nlay
       do icol = 1, ncol
         ! index and factor for temperature interpolation
@@ -104,7 +106,7 @@ contains
         fpress(icol,ilay) = locpress - float(jpress(icol,ilay))
 
         ! determine if in lower or upper part of atmosphere
-        tropo(icol,ilay) = log(play(icol,ilay)) > press_ref_trop_log
+        tropo(icol,ilay) = play(icol,ilay) > press_ref_trop
       end do
     end do
 


### PR DESCRIPTION
This series of fixes addresses a number of bugs and performance problems the original kernel has. While the code is fine with respect to the Fortran standard, it contains a number of places where contemporary CPUs and GPUs can profit from less latency- and optimizer-sensitive idioms.

@skosukhin This works fine for various experiments I did in ICON with the Intel compiler so I'd really like to see this in production, even if that needs additional work on my side. Since I'm not particularly familiar with the rte-rrtmgp external, I'd appreciate any hint on how to refine this PR.