### PR TITLE
Thomas Jahn's gas optics interpolation fixes

### DIFF
--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -94,7 +94,7 @@ contains
     real(wp) :: jpress_aint
     ! -----------------
     ! local indexes
-    integer :: icol, ilay, iflav, igases_1, igases_2, itropo, itemp, jtemp_
+    integer :: icol, ilay, iflav, igas_1, igas_2, itropo, itemp, jtemp_
 
     press_ref_trop = exp(press_ref_trop_log)
     temp_ref_delta_inv = 1.0_wp / temp_ref_delta
@@ -119,8 +119,8 @@ contains
     end do
 
     do iflav = 1, nflav
-      igases_1 = flavor(1,iflav)
-      igases_2 = flavor(2,iflav)
+      igas_1 = flavor(1,iflav)
+      igas_2 = flavor(2,iflav)
       do ilay = 1, nlay
         do icol = 1, ncol
         ! itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
@@ -130,9 +130,9 @@ contains
             ! compute interpolation fractions needed for lower, then upper reference temperature level
             ! compute binary species parameter (eta) for flavor and temperature and
             !  associated interpolation index and factors
-            ratio_eta_half = vmr_ref(itropo,igases_1,(jtemp(icol,ilay)+itemp-1)) / &
-                             vmr_ref(itropo,igases_2,(jtemp(icol,ilay)+itemp-1))
-            col_mix(itemp,icol,ilay,iflav) = col_gas(icol,ilay,igases_1) + ratio_eta_half * col_gas(icol,ilay,igases_2)
+            ratio_eta_half = vmr_ref(itropo,igas_1,(jtemp(icol,ilay)+itemp-1)) / &
+                             vmr_ref(itropo,igas_2,(jtemp(icol,ilay)+itemp-1))
+            col_mix(itemp,icol,ilay,iflav) = col_gas(icol,ilay,igas_1) + ratio_eta_half * col_gas(icol,ilay,igas_2)
             ! Keep this commented lines. Fortran does allow for
             ! substantial optimizations and in this merge cases may
             ! happen that all expressions are evaluated and so create
@@ -140,12 +140,12 @@ contains
             ! save. Merge is the way to do it in general inside of
             ! loops, but sometimes it may not work.
             !
-            ! eta = merge(col_gas(icol,ilay,igases_1) / col_mix(itemp,icol,ilay,iflav), 0.5_wp, &
+            ! eta = merge(col_gas(icol,ilay,igas_1) / col_mix(itemp,icol,ilay,iflav), 0.5_wp, &
             !             col_mix(itemp,icol,ilay,iflav) > 2._wp * tiny(col_mix))
             !
             ! In essence: do not turn it back to merge(...)!
             if (col_mix(itemp,icol,ilay,iflav) > 2._wp * tiny(col_mix)) then
-              eta = col_gas(icol,ilay,igases_1) / col_mix(itemp,icol,ilay,iflav)
+              eta = col_gas(icol,ilay,igas_1) / col_mix(itemp,icol,ilay,iflav)
             else
               eta = 0.5_wp
             endif

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -431,9 +431,9 @@ program rte_check_equivalence
     if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) then 
-       print *, allclose(tst_flux_up, ref_flux_up, tol = 10._wp), & 
-                allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp), & 
-                allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)
+       print *, allclose(tst_flux_up, ref_flux_up, tol = 8._wp), & 
+                allclose(tst_flux_dn, ref_flux_dn, tol = 12._wp), & 
+                allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)
       call report_err("  halving/doubling fails")
     end if 
 

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -296,8 +296,8 @@ program rte_check_equivalence
                             lw_sources, &
                             sfc_emis,   &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn) )    & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol=4._wp) .or. & 
+       .not. allclose(tst_flux_dn, ref_flux_dn, tol=4._wp) )    & 
       call report_err("  halving/doubling fails")
 
     call increment_with_1scl(atmos)

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -430,7 +430,7 @@ program rte_check_equivalence
                             fluxes))
     if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 12._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)) 
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)) & 
       call report_err("  halving/doubling fails")
 
     !

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -296,8 +296,8 @@ program rte_check_equivalence
                             lw_sources, &
                             sfc_emis,   &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol=4._wp) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn, tol=4._wp) )    & 
+    if(.not. allclose(tst_flux_up, ref_flux_up) .or. & 
+       .not. allclose(tst_flux_dn, ref_flux_dn) )    & 
       call report_err("  halving/doubling fails")
 
     call increment_with_1scl(atmos)
@@ -428,7 +428,7 @@ program rte_check_equivalence
     call stop_on_err(rte_sw(atmos, mu0, toa_flux,     &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
       call report_err("  halving/doubling fails")
@@ -446,7 +446,7 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
       call report_err("  Incrementing with 1scl fails")
@@ -461,7 +461,7 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
       call report_err("  Incrementing with 2str fails")
@@ -476,7 +476,7 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
       call report_err("  Incrementing with nstr fails")

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -430,8 +430,12 @@ program rte_check_equivalence
                             fluxes))
     if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
        .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) then 
+       print *, allclose(tst_flux_up, ref_flux_up, tol = 10._wp), & 
+                allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp), & 
+                allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)
       call report_err("  halving/doubling fails")
+    end if 
 
     !
     ! Incremement with 0 optical depth 

--- a/tests/check_equivalence.F90
+++ b/tests/check_equivalence.F90
@@ -428,14 +428,10 @@ program rte_check_equivalence
     call stop_on_err(rte_sw(atmos, mu0, toa_flux,     &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) then 
-       print *, allclose(tst_flux_up, ref_flux_up, tol = 8._wp), & 
-                allclose(tst_flux_dn, ref_flux_dn, tol = 12._wp), & 
-                allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 12._wp) .or. & 
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)) 
       call report_err("  halving/doubling fails")
-    end if 
 
     !
     ! Incremement with 0 optical depth 
@@ -450,9 +446,9 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 12._wp) .or. & 
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)) &  
       call report_err("  Incrementing with 1scl fails")
 
     call stop_on_err(gas_optics%gas_optics(p_lay, p_lev, &
@@ -465,9 +461,9 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 12._wp) .or. & 
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)) &  
       call report_err("  Incrementing with 2str fails")
 
     call stop_on_err(gas_optics%gas_optics(p_lay, p_lev, &
@@ -480,9 +476,9 @@ program rte_check_equivalence
                             mu0,   toa_flux, &
                             sfc_alb_dir, sfc_alb_dif, &
                             fluxes))
-    if(.not. allclose(tst_flux_up, ref_flux_up, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 10._wp) .or. & 
-       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 10._wp)) &  
+    if(.not. allclose(tst_flux_up, ref_flux_up, tol =  8._wp) .or. & 
+       .not. allclose(tst_flux_dn, ref_flux_dn, tol = 12._wp) .or. & 
+       .not. allclose(tst_flux_dir,ref_flux_dir,tol = 12._wp)) &  
       call report_err("  Incrementing with nstr fails")
     print *, "  Incrementing"
   end if 


### PR DESCRIPTION
This is an addition on top of #312 that adjusts tolerances in `tests/test_equivalence` to allow `nvfortran` to pass the CI with double precision. 