### PR TITLE
CMake: add missing test dependencies

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -56,8 +56,7 @@ jobs:
       NetCDF_Fortran_ROOT: /opt/netcdf-fortran
       CMAKE_BUILD_PARALLEL_LEVEL: 8
       VERBOSE:
-      # TODO: add missing test dependencies and run them in parallel:
-      # CTEST_PARALLEL_LEVEL: 8
+      CTEST_PARALLEL_LEVEL: 8
       CTEST_OUTPUT_ON_FAILURE: 1
       # https://github.com/earth-system-radiation/rte-rrtmgp/issues/194
       OMP_TARGET_OFFLOAD: DISABLED

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -61,7 +61,7 @@ jobs:
             fpmodel: SP
     env:
       FC: gfortran-${{ matrix.gfortran-version }}
-      FFLAGS: "-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -fmodule-private -fimplicit-none -finit-real=nan"
+      FFLAGS: "-m64 -std=f2008 -march=native -fbounds-check -fmodule-private -fimplicit-none -finit-real=nan"
       CMAKE_BUILD_PARALLEL_LEVEL: 8
       VERBOSE:
       # TODO: add missing test dependencies and run them in parallel:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,8 +64,7 @@ jobs:
       FFLAGS: "-m64 -std=f2008 -march=native -fbounds-check -fmodule-private -fimplicit-none -finit-real=nan"
       CMAKE_BUILD_PARALLEL_LEVEL: 8
       VERBOSE:
-      # TODO: add missing test dependencies and run them in parallel:
-      # CTEST_PARALLEL_LEVEL: 8
+      CTEST_PARALLEL_LEVEL: 8
       CTEST_OUTPUT_ON_FAILURE: 1
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -10,8 +10,7 @@
   variables:
     CMAKE_BUILD_PARALLEL_LEVEL: 8
     VERBOSE:
-    # TODO: add missing test dependencies and run them in parallel:
-    # CTEST_PARALLEL_LEVEL: 8
+    CTEST_PARALLEL_LEVEL: 8
     CTEST_OUTPUT_ON_FAILURE: 1
   script:
     #

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -1,12 +1,10 @@
 .dp:
   variables:
     RTE_ENABLE_SP: OFF
-    FAILURE_THRESHOLD: "7.e-4"
 
 .sp:
   variables:
     RTE_ENABLE_SP: ON
-    FAILURE_THRESHOLD: "3.5e-1"
 
 .common:
   variables:
@@ -24,8 +22,7 @@
           -DCMAKE_BUILD_TYPE=None \
           -DRTE_ENABLE_SP=$RTE_ENABLE_SP \
           -DKERNEL_MODE=$KERNEL_MODE \
-          -DBUILD_TESTING=ON \
-          -DFAILURE_THRESHOLD=$FAILURE_THRESHOLD
+          -DBUILD_TESTING=ON
     - cmake --build build
     #
     # Run examples, tests and checks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,23 +53,35 @@ exit(tuple(map(int, xarray.__version__.split('.'))) < (0, 12, 2))"
 
   find_package(NetCDF_Fortran REQUIRED)
 
-  if(NOT RRTMGP_DATA)
-    set(RRTMGP_DATA
-        "${PROJECT_BINARY_DIR}/rrtmgp-data"
-        CACHE PATH "Path to the RRTMGP data" FORCE
-    )
-    set(RRTMGP_DATA_VERSION "v1.8.2")
-    include(FetchContent)
-    message(CHECK_START "Fetching RRTMGP data ${RRTMGP_DATA_VERSION}")
-    FetchContent_Declare(
+  if(RRTMGP_DATA)
+    add_test(NAME fetch_rrtmgp_data COMMAND ${CMAKE_COMMAND} -E true)
+  else()
+    set(RRTMGP_DATA "${PROJECT_BINARY_DIR}/rrtmgp-data")
+
+    include(ExternalProject)
+    ExternalProject_Add(
       rrtmgp-data
       GIT_REPOSITORY https://github.com/earth-system-radiation/rrtmgp-data.git
-      GIT_TAG ${RRTMGP_DATA_VERSION}
+      GIT_TAG "v1.8.2"
+      GIT_SHALLOW True
+      EXCLUDE_FROM_ALL True
+      PREFIX rrtmgp-data-cmake
       SOURCE_DIR ${RRTMGP_DATA}
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      INSTALL_COMMAND ""
     )
-    FetchContent_MakeAvailable(rrtmgp-data)
-    message(CHECK_PASS "done")
+    add_test(
+      NAME fetch_rrtmgp_data
+      COMMAND
+        ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --config
+        "$<CONFIG>" --target rrtmgp-data
+    )
   endif()
+
+  set_tests_properties(
+    fetch_rrtmgp_data PROPERTIES FIXTURES_SETUP fetch_rrtmgp_data
+  )
 
   add_subdirectory(examples)
   add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,23 +33,31 @@ add_subdirectory(rrtmgp-frontend)
 include(CTest)
 if(BUILD_TESTING)
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
-  include(CheckPython3Package)
-  check_python3_package(numpy)
-  check_python3_package(
-    "netCDF4 or h5netcdf+scipy"
-    CODE "try:
+
+  if(NOT _RTE_RRTMGP_HAVE_PY_PACKAGES)
+    include(CheckPython3Package)
+    check_python3_package(numpy)
+    check_python3_package(
+      "netCDF4 or h5netcdf+scipy"
+      CODE "try:
     import netCDF4
 except:
     import h5netcdf
     import scipy
 "
-  )
-  check_python3_package(
-    "xarray>=0.12.2"
-    CODE "import xarray
+    )
+    check_python3_package(
+      "xarray>=0.12.2"
+      CODE "import xarray
 exit(tuple(map(int, xarray.__version__.split('.'))) < (0, 12, 2))"
-  )
-  check_python3_package(dask.array)
+    )
+    check_python3_package(dask.array)
+    set(_RTE_RRTMGP_HAVE_PY_PACKAGES
+        TRUE
+        CACHE INTERNAL
+              "RTE-RRTMGP found all Python packages required for testing"
+    )
+  endif()
 
   find_package(NetCDF_Fortran REQUIRED)
 

--- a/examples/all-sky/CMakeLists.txt
+++ b/examples/all-sky/CMakeLists.txt
@@ -1,18 +1,3 @@
-set(TEST_INPUTS
-    ${RRTMGP_DATA}/examples/all-sky/reference/rrtmgp-allsky-lw.nc
-    ${RRTMGP_DATA}/examples/all-sky/reference/rrtmgp-allsky-sw.nc
-    ${RRTMGP_DATA}/examples/all-sky/reference/rrtmgp-allsky-lw-no-aerosols.nc
-    ${RRTMGP_DATA}/examples/all-sky/reference/rrtmgp-allsky-sw-no-aerosols.nc
-)
-
-add_custom_target(
-  all_sky_test_inputs ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${TEST_INPUTS}
-    ${CMAKE_CURRENT_BINARY_DIR}/
-  COMMENT "Copying required test input files"
-)
-
 add_library(
   all_sky_utils STATIC # cmake-format: sort
   mo_load_aerosol_coefficients.F90 mo_load_cloud_coefficients.F90
@@ -22,7 +7,6 @@ target_link_libraries(all_sky_utils PUBLIC examples_utils)
 
 add_executable(rrtmgp_allsky rrtmgp_allsky.F90)
 target_link_libraries(rrtmgp_allsky PRIVATE all_sky_utils)
-add_dependencies(rrtmgp_allsky all_sky_test_inputs)
 
 add_test(
   NAME allsky_test_lw

--- a/examples/all-sky/CMakeLists.txt
+++ b/examples/all-sky/CMakeLists.txt
@@ -9,34 +9,22 @@ add_executable(rrtmgp_allsky rrtmgp_allsky.F90)
 target_link_libraries(rrtmgp_allsky PRIVATE all_sky_utils)
 
 add_test(
-  NAME allsky_test_lw
+  NAME run_allsky_lw
   COMMAND
     rrtmgp_allsky 24 72 1 rrtmgp-allsky-lw.nc
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc
     ${RRTMGP_DATA}/rrtmgp-aerosols-merra-lw.nc
 )
+set_tests_properties(run_allsky_lw PROPERTIES FIXTURES_SETUP run_allsky_lw)
 
 add_test(
-  NAME allsky_test_sw
+  NAME run_allsky_sw
   COMMAND
     rrtmgp_allsky 24 72 1 rrtmgp-allsky-sw.nc
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc ${RRTMGP_DATA}/rrtmgp-clouds-sw.nc
     ${RRTMGP_DATA}/rrtmgp-aerosols-merra-sw.nc
 )
-
-add_test(
-  NAME allsky_test_lw_no_aerosols
-  COMMAND
-    rrtmgp_allsky 24 72 1 rrtmgp-allsky-lw-no-aerosols.nc
-    ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc
-)
-
-add_test(
-  NAME allsky_test_sw_no_aerosols
-  COMMAND
-    rrtmgp_allsky 24 72 1 rrtmgp-allsky-sw-no-aerosols.nc
-    ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc ${RRTMGP_DATA}/rrtmgp-clouds-sw.nc
-)
+set_tests_properties(run_allsky_sw PROPERTIES FIXTURES_SETUP run_allsky_sw)
 
 add_test(
   NAME check_allsky_lw_sw
@@ -47,6 +35,29 @@ add_test(
     sw_flux_dn sw_flux_dir --file_names rrtmgp-allsky-lw.nc rrtmgp-allsky-sw.nc
     --failure_threshold ${FAILURE_THRESHOLD}
 )
+set_tests_properties(
+  check_allsky_lw_sw PROPERTIES FIXTURES_REQUIRED "run_allsky_lw;run_allsky_sw"
+)
+
+add_test(
+  NAME run_allsky_no_aerosols_lw
+  COMMAND
+    rrtmgp_allsky 24 72 1 rrtmgp-allsky-lw-no-aerosols.nc
+    ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc
+)
+set_tests_properties(
+  run_allsky_no_aerosols_lw PROPERTIES FIXTURES_SETUP run_allsky_no_aerosols_lw
+)
+
+add_test(
+  NAME run_allsky_no_aerosols_sw
+  COMMAND
+    rrtmgp_allsky 24 72 1 rrtmgp-allsky-sw-no-aerosols.nc
+    ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc ${RRTMGP_DATA}/rrtmgp-clouds-sw.nc
+)
+set_tests_properties(
+  run_allsky_no_aerosols_sw PROPERTIES FIXTURES_SETUP run_allsky_no_aerosols_sw
+)
 
 add_test(
   NAME check_allsky_no_aerosols_lw_sw
@@ -56,4 +67,9 @@ add_test(
     ${CMAKE_CURRENT_BINARY_DIR} --variables lw_flux_up lw_flux_dn sw_flux_up
     sw_flux_dn sw_flux_dir --file_names rrtmgp-allsky-lw-no-aerosols.nc
     rrtmgp-allsky-sw-no-aerosols.nc --failure_threshold ${FAILURE_THRESHOLD}
+)
+set_tests_properties(
+  check_allsky_no_aerosols_lw_sw
+  PROPERTIES FIXTURES_REQUIRED
+             "run_allsky_no_aerosols_lw;run_allsky_no_aerosols_sw"
 )

--- a/examples/all-sky/CMakeLists.txt
+++ b/examples/all-sky/CMakeLists.txt
@@ -15,7 +15,10 @@ add_test(
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc
     ${RRTMGP_DATA}/rrtmgp-aerosols-merra-lw.nc
 )
-set_tests_properties(run_allsky_lw PROPERTIES FIXTURES_SETUP run_allsky_lw)
+set_tests_properties(
+  run_allsky_lw
+  PROPERTIES FIXTURES_REQUIRED fetch_rrtmgp_data FIXTURES_SETUP run_allsky
+)
 
 add_test(
   NAME run_allsky_sw
@@ -24,7 +27,10 @@ add_test(
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc ${RRTMGP_DATA}/rrtmgp-clouds-sw.nc
     ${RRTMGP_DATA}/rrtmgp-aerosols-merra-sw.nc
 )
-set_tests_properties(run_allsky_sw PROPERTIES FIXTURES_SETUP run_allsky_sw)
+set_tests_properties(
+  run_allsky_sw
+  PROPERTIES FIXTURES_REQUIRED fetch_rrtmgp_data FIXTURES_SETUP run_allsky
+)
 
 add_test(
   NAME check_allsky_lw_sw
@@ -36,7 +42,8 @@ add_test(
     --failure_threshold ${FAILURE_THRESHOLD}
 )
 set_tests_properties(
-  check_allsky_lw_sw PROPERTIES FIXTURES_REQUIRED "run_allsky_lw;run_allsky_sw"
+  check_allsky_lw_sw
+  PROPERTIES FIXTURES_REQUIRED "fetch_rrtmgp_data;run_allsky"
 )
 
 add_test(
@@ -46,7 +53,11 @@ add_test(
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc
 )
 set_tests_properties(
-  run_allsky_no_aerosols_lw PROPERTIES FIXTURES_SETUP run_allsky_no_aerosols_lw
+  run_allsky_no_aerosols_lw
+  PROPERTIES FIXTURES_REQUIRED
+             fetch_rrtmgp_data
+             FIXTURES_SETUP
+             run_allsky_no_aerosols
 )
 
 add_test(
@@ -56,7 +67,11 @@ add_test(
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc ${RRTMGP_DATA}/rrtmgp-clouds-sw.nc
 )
 set_tests_properties(
-  run_allsky_no_aerosols_sw PROPERTIES FIXTURES_SETUP run_allsky_no_aerosols_sw
+  run_allsky_no_aerosols_sw
+  PROPERTIES FIXTURES_REQUIRED
+             fetch_rrtmgp_data
+             FIXTURES_SETUP
+             run_allsky_no_aerosols
 )
 
 add_test(
@@ -70,6 +85,5 @@ add_test(
 )
 set_tests_properties(
   check_allsky_no_aerosols_lw_sw
-  PROPERTIES FIXTURES_REQUIRED
-             "run_allsky_no_aerosols_lw;run_allsky_no_aerosols_sw"
+  PROPERTIES FIXTURES_REQUIRED "fetch_rrtmgp_data;run_allsky_no_aerosols"
 )

--- a/examples/rfmip-clear-sky/CMakeLists.txt
+++ b/examples/rfmip-clear-sky/CMakeLists.txt
@@ -1,19 +1,3 @@
-set(TEST_INPUTS
-    # cmake-format: sort
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/rld_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/rlu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/rsu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
-)
-
-add_custom_target(
-  copy_rrtmgp_rfmip_inputs ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${TEST_INPUTS}
-    ${CMAKE_CURRENT_BINARY_DIR}/
-  COMMENT "Copying required test input files"
-)
-
 add_library(rfmip_clear_utils STATIC mo_rfmip_io.F90)
 target_link_libraries(rfmip_clear_utils PUBLIC examples_utils)
 
@@ -25,8 +9,31 @@ foreach(
 )
   add_executable(${test_executable} ${test_executable}.F90)
   target_link_libraries(${test_executable} PRIVATE rfmip_clear_utils)
-  add_dependencies(${test_executable} copy_rrtmgp_rfmip_inputs)
 endforeach()
+
+set(inoutputs
+    rld_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
+    rlu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
+    rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
+    rsu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
+)
+
+list(
+  TRANSFORM inoutputs
+  PREPEND ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/
+          OUTPUT_VARIABLE inputs
+)
+
+# The tests write to the input files, therefore we copy them:
+add_test(
+  NAME copy_rrtmgp_rfmip_inputs
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different ${inputs}
+    ${CMAKE_CURRENT_BINARY_DIR}/
+)
+set_tests_properties(
+  copy_rrtmgp_rfmip_inputs PROPERTIES FIXTURES_SETUP copy_rrtmgp_rfmip_inputs
+)
 
 add_test(
   NAME run_rrtmgp_rfmip_lw
@@ -36,7 +43,11 @@ add_test(
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
 )
 set_tests_properties(
-  run_rrtmgp_rfmip_lw PROPERTIES FIXTURES_SETUP run_rrtmgp_rfmip_lw
+  run_rrtmgp_rfmip_lw
+  PROPERTIES FIXTURES_REQUIRED
+             copy_rrtmgp_rfmip_inputs
+             FIXTURES_SETUP
+             run_rrtmgp_rfmip_lw
 )
 
 add_test(
@@ -47,7 +58,11 @@ add_test(
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
 )
 set_tests_properties(
-  run_rrtmgp_rfmip_sw PROPERTIES FIXTURES_SETUP run_rrtmgp_rfmip_sw
+  run_rrtmgp_rfmip_sw
+  PROPERTIES FIXTURES_REQUIRED
+             copy_rrtmgp_rfmip_inputs
+             FIXTURES_SETUP
+             run_rrtmgp_rfmip_sw
 )
 
 add_test(
@@ -56,11 +71,7 @@ add_test(
     ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/examples/compare-to-reference.py
     --ref_dir ${RRTMGP_DATA}/examples/rfmip-clear-sky/reference --tst_dir
     ${CMAKE_CURRENT_BINARY_DIR} --variables rld rlu rsd rsu --file_names
-    rld_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
-    rlu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
-    rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
-    rsu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc --failure_threshold
-    ${FAILURE_THRESHOLD}
+    ${inoutputs} --failure_threshold ${FAILURE_THRESHOLD}
 )
 set_tests_properties(
   check_rfmip_lw_sw

--- a/examples/rfmip-clear-sky/CMakeLists.txt
+++ b/examples/rfmip-clear-sky/CMakeLists.txt
@@ -32,7 +32,11 @@ add_test(
     ${CMAKE_CURRENT_BINARY_DIR}/
 )
 set_tests_properties(
-  copy_rrtmgp_rfmip_inputs PROPERTIES FIXTURES_SETUP copy_rrtmgp_rfmip_inputs
+  copy_rrtmgp_rfmip_inputs
+  PROPERTIES FIXTURES_REQUIRED
+             fetch_rrtmgp_data
+             FIXTURES_SETUP
+             copy_rrtmgp_rfmip_inputs
 )
 
 add_test(
@@ -45,9 +49,9 @@ add_test(
 set_tests_properties(
   run_rrtmgp_rfmip_lw
   PROPERTIES FIXTURES_REQUIRED
-             copy_rrtmgp_rfmip_inputs
+             "fetch_rrtmgp_data;copy_rrtmgp_rfmip_inputs"
              FIXTURES_SETUP
-             run_rrtmgp_rfmip_lw
+             run_rrtmgp_rfmip
 )
 
 add_test(
@@ -60,9 +64,9 @@ add_test(
 set_tests_properties(
   run_rrtmgp_rfmip_sw
   PROPERTIES FIXTURES_REQUIRED
-             copy_rrtmgp_rfmip_inputs
+             "fetch_rrtmgp_data;copy_rrtmgp_rfmip_inputs"
              FIXTURES_SETUP
-             run_rrtmgp_rfmip_sw
+             run_rrtmgp_rfmip
 )
 
 add_test(
@@ -75,5 +79,5 @@ add_test(
 )
 set_tests_properties(
   check_rfmip_lw_sw
-  PROPERTIES FIXTURES_REQUIRED "run_rrtmgp_rfmip_lw;run_rrtmgp_rfmip_sw"
+  PROPERTIES FIXTURES_REQUIRED "fetch_rrtmgp_data;run_rrtmgp_rfmip"
 )

--- a/examples/rfmip-clear-sky/CMakeLists.txt
+++ b/examples/rfmip-clear-sky/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(TEST_INPUTS
     # cmake-format: sort
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/rld_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
     ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/rlu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
     ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
@@ -33,7 +32,7 @@ add_test(
   NAME rfmip_test_lw
   COMMAND
     rrtmgp_rfmip_lw 8
-    multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
 )
 
@@ -41,7 +40,7 @@ add_test(
   NAME rfmip_test_sw
   COMMAND
     rrtmgp_rfmip_sw 8
-    multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
 )
 

--- a/examples/rfmip-clear-sky/CMakeLists.txt
+++ b/examples/rfmip-clear-sky/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TEST_INPUTS
 )
 
 add_custom_target(
-  rfmip_clear_sky_test_inputs ALL
+  copy_rrtmgp_rfmip_inputs ALL
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different ${TEST_INPUTS}
     ${CMAKE_CURRENT_BINARY_DIR}/
@@ -25,23 +25,29 @@ foreach(
 )
   add_executable(${test_executable} ${test_executable}.F90)
   target_link_libraries(${test_executable} PRIVATE rfmip_clear_utils)
-  add_dependencies(${test_executable} rfmip_clear_sky_test_inputs)
+  add_dependencies(${test_executable} copy_rrtmgp_rfmip_inputs)
 endforeach()
 
 add_test(
-  NAME rfmip_test_lw
+  NAME run_rrtmgp_rfmip_lw
   COMMAND
     rrtmgp_rfmip_lw 8
     ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
 )
+set_tests_properties(
+  run_rrtmgp_rfmip_lw PROPERTIES FIXTURES_SETUP run_rrtmgp_rfmip_lw
+)
 
 add_test(
-  NAME rfmip_test_sw
+  NAME run_rrtmgp_rfmip_sw
   COMMAND
     rrtmgp_rfmip_sw 8
     ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
+)
+set_tests_properties(
+  run_rrtmgp_rfmip_sw PROPERTIES FIXTURES_SETUP run_rrtmgp_rfmip_sw
 )
 
 add_test(
@@ -55,4 +61,8 @@ add_test(
     rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc
     rsu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f1_gn.nc --failure_threshold
     ${FAILURE_THRESHOLD}
+)
+set_tests_properties(
+  check_rfmip_lw_sw
+  PROPERTIES FIXTURES_REQUIRED "run_rrtmgp_rfmip_lw;run_rrtmgp_rfmip_sw"
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,15 +1,3 @@
-set(TEST_INPUTS
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
-)
-
-add_custom_target(
-  tests_test_inputs ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${TEST_INPUTS}
-    ${CMAKE_CURRENT_BINARY_DIR}/
-  COMMENT "Copying required test input files"
-)
-
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules)
 
 set(extensions_source_dir ${PROJECT_SOURCE_DIR}/extensions)
@@ -50,9 +38,6 @@ foreach(
   target_link_libraries(${test_executable} PRIVATE test_utils)
 endforeach()
 
-add_dependencies(check_equivalence tests_test_inputs)
-add_dependencies(check_variants tests_test_inputs)
-
 add_test(NAME rte_optic_prop_unit_tests COMMAND rte_optic_prop_unit_tests)
 add_test(NAME rte_lw_solver_unit_tests COMMAND rte_lw_solver_unit_tests)
 add_test(NAME rte_sw_solver_unit_tests COMMAND rte_sw_solver_unit_tests)
@@ -61,7 +46,7 @@ add_test(
   NAME check_equivalence_lw_g256
   COMMAND
     check_equivalence
-    multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
 )
 
@@ -69,7 +54,7 @@ add_test(
   NAME check_equivalence_lw_g128
   COMMAND
     check_equivalence
-    multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc
 )
 
@@ -77,7 +62,7 @@ add_test(
   NAME check_equivalence_sw_g224
   COMMAND
     check_equivalence
-    multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
 )
 
@@ -85,8 +70,20 @@ add_test(
   NAME check_equivalence_sw_g112
   COMMAND
     check_equivalence
-    multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc
+)
+
+# The tests write to the input file, therefore we copy it:
+add_test(
+  NAME copy_check_variants_input
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+    ${CMAKE_CURRENT_BINARY_DIR}/
+)
+set_tests_properties(
+  copy_check_variants_input PROPERTIES FIXTURES_SETUP copy_check_variants_input
 )
 
 add_test(
@@ -96,6 +93,13 @@ add_test(
     multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc
 )
+set_tests_properties(
+  check_variants_lw
+  PROPERTIES FIXTURES_REQUIRED
+             copy_check_variants_input
+             FIXTURES_SETUP
+             check_variants_lw
+)
 
 add_test(
   NAME check_variants_sw
@@ -103,6 +107,12 @@ add_test(
     check_variants
     multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
     ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc
+)
+set_tests_properties(
+  check_variants_sw
+  # The test writes to the same file as check_variants_lw, therefore we must not
+  # run them in parallel:
+  PROPERTIES FIXTURES_REQUIRED check_variants_lw
 )
 
 add_custom_target(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,41 +38,43 @@ foreach(
   target_link_libraries(${test_executable} PRIVATE test_utils)
 endforeach()
 
-add_test(NAME rte_optic_prop_unit_tests COMMAND rte_optic_prop_unit_tests)
-add_test(NAME rte_lw_solver_unit_tests COMMAND rte_lw_solver_unit_tests)
-add_test(NAME rte_sw_solver_unit_tests COMMAND rte_sw_solver_unit_tests)
-
-add_test(
-  NAME check_equivalence_lw_g256
-  COMMAND
-    check_equivalence
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
-    ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
+foreach(
+  test_executable IN
+  ITEMS # cmake-format: sort
+        rte_lw_solver_unit_tests
+        rte_optic_prop_unit_tests
+        rte_sw_solver_unit_tests
 )
+  add_test(NAME ${test_executable} COMMAND ${test_executable})
+endforeach()
 
-add_test(
-  NAME check_equivalence_lw_g128
-  COMMAND
-    check_equivalence
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
-    ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc
-)
+foreach(g_value IN ITEMS 256 128)
+  add_test(
+    NAME check_equivalence_lw_g${g_value}
+    COMMAND
+      check_equivalence
+      ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+      ${RRTMGP_DATA}/rrtmgp-gas-lw-g${g_value}.nc
+  )
+  set_tests_properties(
+    check_equivalence_lw_g${g_value}
+    PROPERTIES FIXTURES_REQUIRED fetch_rrtmgp_data
+  )
+endforeach()
 
-add_test(
-  NAME check_equivalence_sw_g224
-  COMMAND
-    check_equivalence
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
-    ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
-)
-
-add_test(
-  NAME check_equivalence_sw_g112
-  COMMAND
-    check_equivalence
-    ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
-    ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc
-)
+foreach(g_value IN ITEMS 224 112)
+  add_test(
+    NAME check_equivalence_sw_g${g_value}
+    COMMAND
+      check_equivalence
+      ${RRTMGP_DATA}/examples/rfmip-clear-sky/inputs/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc
+      ${RRTMGP_DATA}/rrtmgp-gas-sw-g${g_value}.nc
+  )
+  set_tests_properties(
+    check_equivalence_sw_g${g_value}
+    PROPERTIES FIXTURES_REQUIRED fetch_rrtmgp_data
+  )
+endforeach()
 
 # The tests write to the input file, therefore we copy it:
 add_test(
@@ -83,7 +85,11 @@ add_test(
     ${CMAKE_CURRENT_BINARY_DIR}/
 )
 set_tests_properties(
-  copy_check_variants_input PROPERTIES FIXTURES_SETUP copy_check_variants_input
+  copy_check_variants_input
+  PROPERTIES FIXTURES_REQUIRED
+             fetch_rrtmgp_data
+             FIXTURES_SETUP
+             copy_check_variants_input
 )
 
 add_test(
@@ -95,10 +101,7 @@ add_test(
 )
 set_tests_properties(
   check_variants_lw
-  PROPERTIES FIXTURES_REQUIRED
-             copy_check_variants_input
-             FIXTURES_SETUP
-             check_variants_lw
+  PROPERTIES FIXTURES_REQUIRED "fetch_rrtmgp_data;copy_check_variants_input"
 )
 
 add_test(
@@ -110,9 +113,12 @@ add_test(
 )
 set_tests_properties(
   check_variants_sw
-  # The test writes to the same file as check_variants_lw, therefore we must not
-  # run them in parallel:
-  PROPERTIES FIXTURES_REQUIRED check_variants_lw
+  PROPERTIES FIXTURES_REQUIRED
+             "fetch_rrtmgp_data;copy_check_variants_input"
+             # The test writes to the same file as check_variants_lw, therefore
+             # we cannot run them in parallel:
+             DEPENDS
+             check_variants_lw
 )
 
 add_custom_target(


### PR DESCRIPTION
This solves several issues related to the tests:
- `examples/all-sky`: currently, CMake copies [files from `${RRTMGP_DATA}`](https://github.com/earth-system-radiation/rte-rrtmgp/blob/e13d20e5b6c3df99188f6564c415976a3438d316/examples/all-sky/CMakeLists.txt#L2-L5) to the build directory at the configure stage. The files are then fully overwritten by `rrtmgp_allsky` at the test stage. So, there is no point in copying. Another problem is that this might lead to false positive results of `compare-to-reference.py`: the script succeeds even if `rrtmgp_allsky` was never run. This PR drops the copying and makes sure that `compare-to-reference.py` runs only when the respective `rrtmgp_allsky` runs are finished successfully (see the `FIXTURES_SETUP`/`FIXTURES_REQUIRED` properties of the tests).
- `examples/rfmip-clear-sky`: we don't need to copy `multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc` because the test programs don't modify it and accept the path to the file as the command line argument. Unfortunately, this is not the case for all the [other input files](https://github.com/earth-system-radiation/rte-rrtmgp/blob/e13d20e5b6c3df99188f6564c415976a3438d316/examples/rfmip-clear-sky/CMakeLists.txt#L4-L7). Not only it is impossible to specify paths to the files on the command line but the test programs also write to the files. As before, those files are currently copied at the configure stage and there is a lot that can happen before the test stage. Therefore, the PR implements the copying as a separate "test". This way, there is a much higher chance that the input files for the tests are the ones we expect them to be (e.g. if we run `ctest` several times, we now get "fresh" input files each time and not only for the first run).
    `TODO:` consider rewriting the test programs so that they do not write to the input files but produce new ones in the build directory. Ideally, we should also make it possible to specify paths to the files on the command line to fully eliminate the need for copying.
- `tests`: `check_variants` writes to the input file. Therefore, we have to copy `multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc` to the build directory. Moreover, we have to make sure that `check_variants_lw` and `check_variants_sw` are not run in parallel since they write to the same file (see the `DEPENDS` property of `check_variants_sw`). On the other hand, `check_equivalence` does not need a copy of the file and can run against the original one from `${RRTMGP_DATA}`. Hence, the respective tests don't need to wait for the copying to finish.
    `TODO:` consider rewriting the test programs (and probably `validation-plots.py`) to make the copying redundant.
- as I mentioned above, a lot can happen between the configure and the test stages. Therefore, this PR makes the fetching of the input data from [`rrtmgp-data`](https://github.com/earth-system-radiation/rrtmgp-data) an extra "test", which is required by all tests that need the data. This way, we make sure that the expected tag is cloned from the data repository right before running the tests. It is also nice to be able to configure with `-DBUILD_TESTING=ON` without making the configure stage too long and fetch the data only when running `ctest`. If the users already have the required data locally, they can suppress the fetching by configuring with `-DRRTMGP_DATA=/path/to/local/copy/of/rrtmgp-data`. When the variable is provided, the extra "test" `fetch_rrtmgp_data` becomes a simple `cmake -E true`.
- this PR introduces an internal cache variable `_RTE_RRTMGP_HAVE_PY_PACKAGES` to avoid rerunning the checks for the required Python packages over and over again.
- CI jobs now run the tests in parallel.
- the PR also fixes a couple of things that I forgot to do in #316: the GitLab pipelines now use the same default values for `FAILURE_THRESHOLD` as all other tests and all `gfortran` tests don't need the `-ffree-line-length-none` flag to be set via `FFLAGS` since it is [injected by CMake automatically](https://github.com/earth-system-radiation/rte-rrtmgp/blob/e13d20e5b6c3df99188f6564c415976a3438d316/CMakeLists.txt#L23).