### PR TITLE
CI: disable ifx accel jobs

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -18,6 +18,12 @@ jobs:
         fortran-compiler: [ifort, ifx, nvfortran]
         rte-kernels: [default, accel]
         fpmodel: [DP, SP]
+        exclude:
+        # Fails with error #5633: **Internal compiler error: segmentation violation signal raised**
+        - fortran-compiler: ifx
+          rte-kernels: accel
+          # fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08 -fiopenmp -fopenmp-targets=spir64
+          # build-type: None
         include:
         # Set flags for Intel Fortran Compiler Classic
         - fortran-compiler: ifort
@@ -27,10 +33,6 @@ jobs:
         - fortran-compiler: ifx
           rte-kernels: default
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          build-type: None
-        - fortran-compiler: ifx
-          rte-kernels: accel
-          fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08 -fiopenmp -fopenmp-targets=spir64
           build-type: None
         # Set flags for NVIDIA Fortran compiler
         - fortran-compiler: nvfortran
@@ -75,11 +77,9 @@ jobs:
         apt-get update
         apt-get install -y git cmake ninja-build
     #
-    # Build libraries, examples and tests (expect success)
+    # Build libraries, examples and tests
     #
-    - name: Build libraries, examples and tests (expect success)
-      id: build-success
-      if: matrix.fortran-compiler != 'ifx' || matrix.rte-kernels != 'accel'
+    - name: Build libraries, examples and tests
       run: |
           cmake -S . -B build -G "Ninja" \
               -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
@@ -92,7 +92,6 @@ jobs:
     #
     - name: Run examples and tests
       working-directory: build
-      if: steps.build-success.outcome != 'skipped'
       run: ctest
     #
     # Generate validation plots


### PR DESCRIPTION
Currently, the `accel` CI jobs with the `ifx` compiler do nothing but waste resources. We cannot enable them due to an internal compiler error:
```console
rte-frontend/CMakeFiles/rte.dir/mo_rte_sw.F90-pp.f90: error #5633: **Internal compiler error: segmentation violation signal raised** Please report this error along with the circumstances in which it occurred in a Software Problem Report.  Note: File and line given may not be explicit cause of this error.
compilation aborted for rte-frontend/CMakeFiles/rte.dir/mo_rte_sw.F90-pp.f90 (code 3)
```
Instead of skipping the jobs, this PR `exclude`s them from the matrix.