### PR TITLE
CMake: add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,14 @@ set_property(CACHE KERNEL_MODE PROPERTY STRINGS ${PREFERRED_KERNEL_MODES})
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
+# GNUInstallDirs issues a warning if CMAKE_SIZEOF_VOID_P is not defined, which
+# is the case with NAG. One way to circumvent that is to enable C language for
+# the project:
+if(CMAKE_Fortran_COMPILER_ID STREQUAL NAG)
+  enable_language(C)
+endif()
+include(GNUInstallDirs)
+
 add_compile_options(
   $<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-ffree-line-length-none>
 )
@@ -97,3 +105,5 @@ else()
   # Allow for 'make test' even if the tests are disabled:
   enable_testing()
 endif()
+
+install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ TYPE INCLUDE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ else()
   enable_testing()
 endif()
 
+export(
+  EXPORT rte-rrtmgp-targets FILE ${PROJECT_BINARY_DIR}/rte-rrtmgp-targets.cmake
+)
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${PROJECT_SOURCE_DIR}/cmake/config.cmake.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,4 +106,29 @@ else()
   enable_testing()
 endif()
 
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${PROJECT_SOURCE_DIR}/cmake/config.cmake.in
+  ${PROJECT_BINARY_DIR}/rte-rrtmgp-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/rte-rrtmgp/cmake
+  NO_SET_AND_CHECK_MACRO NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+  ${PROJECT_BINARY_DIR}/rte-rrtmgp-config-version.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMinorVersion
+)
+
 install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ TYPE INCLUDE)
+
+install(
+  EXPORT rte-rrtmgp-targets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/rte-rrtmgp/cmake
+)
+
+install(
+  FILES ${PROJECT_BINARY_DIR}/rte-rrtmgp-config.cmake
+        ${PROJECT_BINARY_DIR}/rte-rrtmgp-config-version.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/rte-rrtmgp/cmake
+)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/rte-rrtmgp-targets.cmake)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(rte-rrtmgp REQUIRED_VARS rte-rrtmgp_DIR)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,7 +24,8 @@ target_include_directories(
 )
 
 target_link_libraries(
-  examples_utils PUBLIC rrtmgp rte ${NetCDF_Fortran_LIBRARY}
+  examples_utils
+  PUBLIC rte-rrtmgp::rrtmgp rte-rrtmgp::rte ${NetCDF_Fortran_LIBRARY}
 )
 
 add_subdirectory(all-sky)

--- a/rrtmgp-frontend/CMakeLists.txt
+++ b/rrtmgp-frontend/CMakeLists.txt
@@ -2,6 +2,7 @@ set(gas_optics_source_dir ${PROJECT_SOURCE_DIR}/gas-optics)
 
 add_library(
   rrtmgp STATIC # cmake-format: sort
+  $<TARGET_OBJECTS:rrtmgpkernels>
   ${gas_optics_source_dir}/mo_gas_concentrations.F90
   ${gas_optics_source_dir}/mo_gas_optics.F90
   ${gas_optics_source_dir}/mo_gas_optics_constants.F90
@@ -19,10 +20,6 @@ target_include_directories(
     $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Fortran>:${CMAKE_Fortran_MODULE_DIRECTORY}>>
 )
 
-target_link_libraries(
-  rrtmgp
-  PUBLIC $<BUILD_INTERFACE:rrtmgpkernels>
-  PRIVATE rte
-)
+target_link_libraries(rrtmgp PRIVATE rte)
 
 install(TARGETS rrtmgp EXPORT rte-rrtmgp-targets)

--- a/rrtmgp-frontend/CMakeLists.txt
+++ b/rrtmgp-frontend/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(
   mo_gas_optics_rrtmgp.F90
 )
 
+add_library(rte-rrtmgp::rrtmgp ALIAS rrtmgp)
+
 set_target_properties(rrtmgp PROPERTIES EXPORT_NAME rte-rrtmgp::rrtmgp)
 
 target_include_directories(

--- a/rrtmgp-frontend/CMakeLists.txt
+++ b/rrtmgp-frontend/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(
   mo_gas_optics_rrtmgp.F90
 )
 
+set_target_properties(rrtmgp PROPERTIES EXPORT_NAME rte-rrtmgp::rrtmgp)
+
 target_include_directories(
   rrtmgp
   PUBLIC
@@ -19,7 +21,7 @@ target_include_directories(
 
 target_link_libraries(
   rrtmgp
-  PUBLIC rrtmgpkernels
+  PUBLIC $<BUILD_INTERFACE:rrtmgpkernels>
   PRIVATE rte
 )
 

--- a/rrtmgp-frontend/CMakeLists.txt
+++ b/rrtmgp-frontend/CMakeLists.txt
@@ -22,3 +22,5 @@ target_link_libraries(
   PUBLIC rrtmgpkernels
   PRIVATE rte
 )
+
+install(TARGETS rrtmgp EXPORT rte-rrtmgp-targets)

--- a/rrtmgp-kernels/CMakeLists.txt
+++ b/rrtmgp-kernels/CMakeLists.txt
@@ -30,9 +30,7 @@ else()
 endif()
 
 target_include_directories(
-  rrtmgpkernels
-  PUBLIC
-    $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Fortran>:${CMAKE_Fortran_MODULE_DIRECTORY}>>
+  rrtmgpkernels PRIVATE ${CMAKE_Fortran_MODULE_DIRECTORY}
 )
 
 target_link_libraries(rrtmgpkernels PRIVATE rte)

--- a/rte-frontend/CMakeLists.txt
+++ b/rte-frontend/CMakeLists.txt
@@ -9,12 +9,14 @@ add_library(
   mo_source_functions.F90
 )
 
+set_target_properties(rte PROPERTIES EXPORT_NAME rte-rrtmgp::rte)
+
 target_include_directories(
   rte
   PUBLIC
     $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Fortran>:${CMAKE_Fortran_MODULE_DIRECTORY}>>
 )
 
-target_link_libraries(rte PUBLIC rtekernels)
+target_link_libraries(rte PUBLIC $<BUILD_INTERFACE:rtekernels>)
 
 install(TARGETS rte EXPORT rte-rrtmgp-targets)

--- a/rte-frontend/CMakeLists.txt
+++ b/rte-frontend/CMakeLists.txt
@@ -16,3 +16,5 @@ target_include_directories(
 )
 
 target_link_libraries(rte PUBLIC rtekernels)
+
+install(TARGETS rte EXPORT rte-rrtmgp-targets)

--- a/rte-frontend/CMakeLists.txt
+++ b/rte-frontend/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(
   mo_source_functions.F90
 )
 
+add_library(rte-rrtmgp::rte ALIAS rte)
+
 set_target_properties(rte PROPERTIES EXPORT_NAME rte-rrtmgp::rte)
 
 target_include_directories(

--- a/rte-frontend/CMakeLists.txt
+++ b/rte-frontend/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   rte STATIC # cmake-format: sort
+  $<TARGET_OBJECTS:rtekernels>
   mo_fluxes.F90
   mo_optical_props.F90
   mo_rte_config.F90
@@ -16,7 +17,5 @@ target_include_directories(
   PUBLIC
     $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Fortran>:${CMAKE_Fortran_MODULE_DIRECTORY}>>
 )
-
-target_link_libraries(rte PUBLIC $<BUILD_INTERFACE:rtekernels>)
 
 install(TARGETS rte EXPORT rte-rrtmgp-targets)

--- a/rte-kernels/CMakeLists.txt
+++ b/rte-kernels/CMakeLists.txt
@@ -44,8 +44,4 @@ target_compile_definitions(
           $<$<BOOL:${RTE_USE_C_BOOL}>:RTE_USE_CBOOL>
 )
 
-target_include_directories(
-  rtekernels
-  PUBLIC
-    $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Fortran>:${CMAKE_Fortran_MODULE_DIRECTORY}>>
-)
+target_include_directories(rtekernels PRIVATE ${CMAKE_Fortran_MODULE_DIRECTORY})


### PR DESCRIPTION
1. Add the install target. Installs the `rte` and `rrtmgp` libraries together with their module files.
    `TODO:` consider fetching and installing the `rrtmgp-gas-*.nc` data files from [`rrtmgp-data`](https://github.com/earth-system-radiation/rrtmgp-data) as there are users who consider them to be part of the library.
2. Generate and install CMake config, target and version files to enable `find_package(rte-rrtmgp)` in the user projects. The `COMPATIBILITY` is set to `SameMinorVersion`, which means that if the users need version `1.8`, any `1.8.x` version suffices but neither `1.7.x` nor `1.9.x` do.
3. Export the targets to the build directory to make the project locatable from the build directory as well (i.e. `find_package(rte-rrtmgp)` with `CMAKE_PREFIX_PATH` containing `/path/to/rte-rrtmgp/build`). This part also required some tweaks for the `rtekernels` and `rrtmgpkernels` object libraries since we don't want to expose them to the users (at least for now).
4. Add public aliases in the `rte-rrtmgp::` namespace so the project is fetchable and addable (with `add_subdirectory`) by the users' application projects.