### PR TITLE
Update CMake version to 1.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 
 project(
   rte-rrtmgp
-  VERSION 1.8
+  VERSION 1.9.0
   LANGUAGES Fortran
 )
 


### PR DESCRIPTION
Updates CMake project version to 1.9. Github release of 1.9 might have some -alpha candidates while we wait for pending changes. 