### PR TITLE
CMake: install data files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ exit(tuple(map(int, xarray.__version__.split('.'))) < (0, 12, 2))"
 
   if(RRTMGP_DATA)
     add_test(NAME fetch_rrtmgp_data COMMAND ${CMAKE_COMMAND} -E true)
+    message(
+      NOTICE
+      "Using an external dataset from ${RRTMGP_DATA}: the data files will not be installed"
+    )
   else()
     set(RRTMGP_DATA "${PROJECT_BINARY_DIR}/rrtmgp-data")
 
@@ -87,11 +91,26 @@ exit(tuple(map(int, xarray.__version__.split('.'))) < (0, 12, 2))"
       BUILD_COMMAND ""
       INSTALL_COMMAND ""
     )
-    add_test(
-      NAME fetch_rrtmgp_data
-      COMMAND
+
+    set(fetch_rrtmgp_data_command
         ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --config
         "$<CONFIG>" --target rrtmgp-data
+    )
+
+    add_test(NAME fetch_rrtmgp_data COMMAND ${fetch_rrtmgp_data_command})
+
+    install(CODE "execute_process(COMMAND ${fetch_rrtmgp_data_command})")
+    install(
+      FILES # cmake-format: sort
+            ${RRTMGP_DATA}/rrtmgp-aerosols-merra-lw.nc
+            ${RRTMGP_DATA}/rrtmgp-aerosols-merra-sw.nc
+            ${RRTMGP_DATA}/rrtmgp-clouds-lw.nc
+            ${RRTMGP_DATA}/rrtmgp-clouds-sw.nc
+            ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc
+            ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
+            ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc
+            ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
     )
   endif()
 


### PR DESCRIPTION
This extends the `install` target to install all the `*.nc` files in the root of the [rrtmgp-data](https://github.com/earth-system-radiation/rrtmgp-data) (see #325).

As in the case with the tests, the data files are not fetched at the configure stage but at the latest stage possible.