### PR TITLE
Format Python with isort and black

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,13 +1,13 @@
-with section("parse"):
+with section("parse"):  # noqa: F821
     additional_commands = {"check_python3_package": {"pargs": 1, "kwargs": {"CODE": 1}}}
 
-with section("format"):
+with section("format"):  # noqa: F821
     dangle_parens = True
     max_lines_hwrap = 0
     keyword_case = "upper"
     autosort = True
 
-with section("lint"):
+with section("lint"):  # noqa: F821
     # The formatter sometimes fails to fit the code into the line limit (C0301) and can
     # disagree with the linter regarding the indentation (C0307):
     disabled_codes = ["C0301", "C0307"]

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Formatted entire Python code base with isort and black
+XXXXX

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,0 @@
-# Formatted entire CMake code base with cmake-format
-45b43632309cff022326472a8be0fdd5efc8f5c8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
         name: cmake-lint (templates)
         types: [file]
         files: \.cmake\.in$
+  - repo: https://github.com/csachs/pyproject-flake8
+    rev: v7.0.0
+    hooks:
+      - id: pyproject-flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.10.0
+    hooks:
+      - id: black
   - repo: https://github.com/csachs/pyproject-flake8
     rev: v7.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,10 @@ repos:
         name: cmake-lint (templates)
         types: [file]
         files: \.cmake\.in$
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
   - repo: https://github.com/csachs/pyproject-flake8
     rev: v7.0.0
     hooks:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -21,6 +21,9 @@ dependencies:
   - netcdf-fortran
   - cmake
   - ninja
+  - isort
+  - black
+  - flake8
 variables:
   FC: gfortran
   # Debugging flags below

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -23,7 +23,7 @@ dependencies:
   - ninja
   - isort
   - black
-  - flake8
+  - pyproject-flake8
 variables:
   FC: gfortran
   # Debugging flags below

--- a/examples/all-sky/make_problem_size_loop.py
+++ b/examples/all-sky/make_problem_size_loop.py
@@ -76,10 +76,10 @@ if __name__ == "__main__":
         raise AssertionError("Need to supply cloud optics if providing aerosol optics")
 
     # Every combo of ncol, nlay
-    for l in args.nlay:
-        for i in args.ncol:
+    for ll in args.nlay:
+        for ii in args.ncol:
             print(
-                f"{args.executable} {i:6d} {l:4d} {args.nloops:3d} "
+                f"{args.executable} {ii:6d} {ll:4d} {args.nloops:3d} "
                 + f"{args.output_file} {args.k_distribution} "
                 + f"{args.cloud_optics} {args.aerosol_optics} "
             )

--- a/examples/all-sky/make_problem_size_loop.py
+++ b/examples/all-sky/make_problem_size_loop.py
@@ -13,52 +13,73 @@ import csv
 # output name
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description="Description here ")
-    # Argument parseing described at 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Description here ")
+    # Argument parseing described at
     # https://stackoverflow.com/questions/15753701/how-can-i-pass-a-list-as-a-command-line-argument-with-argparse
-    parser.add_argument("-x", "--executable",
-                        type=str,
-                        default="./rrtmgp_allsky",
-                        help="Path to exectuable")
-    parser.add_argument("-c", "--ncol",
-                        type=lambda items: [int(i) for i in
-                                            list(csv.reader([items]))[0]],
-                        default="2,4,8,16",
-                        help="Number of columns  (multiple e.g. 2,4,8,16)")
-    parser.add_argument("-l", "--nlay",
-                        type=lambda items: [int(i) for i in
-                                            list(csv.reader([items]))[0]],
-                        default="32, 64, 96",
-                        help="Number of layers (multiple e.g. 32,64.96)")
-    parser.add_argument("-i", "--nloops",
-                        type=int, default=1,
-                        help="Number of loops (same for all ncol)")
-    parser.add_argument("-o", "--output_file",
-                        type=str,
-                        default="rrtmgp-allsky-output.nc",
-                        help="Path to output file")
-    parser.add_argument("-k", "--k_distribution",
-                        type=str,
-                        required=True,
-                        help="Path to gas optics file [required]")
-    parser.add_argument("-cl", "--cloud_optics",
-                        type=str, default="",
-                        help="Path to cloud optics file")
-    parser.add_argument("-a", "--aerosol_optics",
-                        type=str, default="",
-                        help="Path to aerosol optics file")
+    parser.add_argument(
+        "-x",
+        "--executable",
+        type=str,
+        default="./rrtmgp_allsky",
+        help="Path to exectuable",
+    )
+    parser.add_argument(
+        "-c",
+        "--ncol",
+        type=lambda items: [int(i) for i in list(csv.reader([items]))[0]],
+        default="2,4,8,16",
+        help="Number of columns  (multiple e.g. 2,4,8,16)",
+    )
+    parser.add_argument(
+        "-l",
+        "--nlay",
+        type=lambda items: [int(i) for i in list(csv.reader([items]))[0]],
+        default="32, 64, 96",
+        help="Number of layers (multiple e.g. 32,64.96)",
+    )
+    parser.add_argument(
+        "-i",
+        "--nloops",
+        type=int,
+        default=1,
+        help="Number of loops (same for all ncol)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_file",
+        type=str,
+        default="rrtmgp-allsky-output.nc",
+        help="Path to output file",
+    )
+    parser.add_argument(
+        "-k",
+        "--k_distribution",
+        type=str,
+        required=True,
+        help="Path to gas optics file [required]",
+    )
+    parser.add_argument(
+        "-cl", "--cloud_optics", type=str, default="", help="Path to cloud optics file"
+    )
+    parser.add_argument(
+        "-a",
+        "--aerosol_optics",
+        type=str,
+        default="",
+        help="Path to aerosol optics file",
+    )
     args = parser.parse_args()
 
     # Can't supply aerosols without clouds
     if args.cloud_optics == "" and args.aerosol_optics != "":
-        raise AssertionError(
-            "Need to supply cloud optics if providing aerosol optics")
+        raise AssertionError("Need to supply cloud optics if providing aerosol optics")
 
     # Every combo of ncol, nlay
     for l in args.nlay:
         for i in args.ncol:
-            print(f"{args.executable} {i:6d} {l:4d} {args.nloops:3d} " +
-                  f"{args.output_file} {args.k_distribution} " +
-                  f"{args.cloud_optics} {args.aerosol_optics} ")
+            print(
+                f"{args.executable} {i:6d} {l:4d} {args.nloops:3d} "
+                + f"{args.output_file} {args.k_distribution} "
+                + f"{args.cloud_optics} {args.aerosol_optics} "
+            )

--- a/examples/all-sky/run-allsky-example.py
+++ b/examples/all-sky/run-allsky-example.py
@@ -20,37 +20,63 @@ sw_clouds_coeff_file = os.path.join(rte_rrtmgp_dir, "rrtmgp-clouds-sw.nc")
 # In the local directory
 all_sky_exe_name = os.path.join(all_sky_dir, "rrtmgp_allsky")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Runs all-sky examples, resetting output.")
-    parser.add_argument("--run_command", type=str, default="",
-                        help="Prefix ('jsrun' etc.) for running commands. "
-                             "Use quote marks to enclose multi-part commands.")
-    parser.add_argument("--ncol", type=int, default=24,
-                        help="Number of columns to compute")
-    parser.add_argument("--nlay", type=int, default=72,
-                        help="Number of layers "
-                             "(every one will have the same clouds)")
-    parser.add_argument("--nloops", type=int, default=1,
-                        help="Number of times to compute 'nloops' "
-                             "cloudy columns")
+        description="Runs all-sky examples, resetting output."
+    )
+    parser.add_argument(
+        "--run_command",
+        type=str,
+        default="",
+        help="Prefix ('jsrun' etc.) for running commands. "
+        "Use quote marks to enclose multi-part commands.",
+    )
+    parser.add_argument(
+        "--ncol", type=int, default=24, help="Number of columns to compute"
+    )
+    parser.add_argument(
+        "--nlay",
+        type=int,
+        default=72,
+        help="Number of layers " "(every one will have the same clouds)",
+    )
+    parser.add_argument(
+        "--nloops",
+        type=int,
+        default=1,
+        help="Number of times to compute 'nloops' " "cloudy columns",
+    )
 
     args = parser.parse_args()
-    ncol_str = '{0:5d}'.format(args.ncol)
-    nlay_str = '{0:5d}'.format(args.nlay)
-    nloops_str = '{0:5d}'.format(args.nloops)
+    ncol_str = "{0:5d}".format(args.ncol)
+    nlay_str = "{0:5d}".format(args.nlay)
+    nloops_str = "{0:5d}".format(args.nloops)
     if args.run_command:
         print("using the run command")
         all_sky_exe_name = args.run_command + " " + all_sky_exe_name
     os.chdir(all_sky_dir)
     # Remove cloudy-sky fluxes from the file containing the atmospheric profiles
     subprocess.run(
-        [all_sky_exe_name, ncol_str, nlay_str, nloops_str,
-         "rrtmgp-allsky-lw-no-aerosols.nc", lw_gas_coeffs_file,
-         lw_clouds_coeff_file])
+        [
+            all_sky_exe_name,
+            ncol_str,
+            nlay_str,
+            nloops_str,
+            "rrtmgp-allsky-lw-no-aerosols.nc",
+            lw_gas_coeffs_file,
+            lw_clouds_coeff_file,
+        ]
+    )
     subprocess.run(
-        [all_sky_exe_name, ncol_str, nlay_str, nloops_str,
-         "rrtmgp-allsky-sw-no-aerosols.nc", sw_gas_coeffs_file,
-         sw_clouds_coeff_file])
+        [
+            all_sky_exe_name,
+            ncol_str,
+            nlay_str,
+            nloops_str,
+            "rrtmgp-allsky-sw-no-aerosols.nc",
+            sw_gas_coeffs_file,
+            sw_clouds_coeff_file,
+        ]
+    )
 
 # end main

--- a/examples/compare-to-reference.py
+++ b/examples/compare-to-reference.py
@@ -1,87 +1,104 @@
 #! /usr/bin/env python
 #
-# General purpose comparison script -- compare all variables in a set of files, 
-#   write output if differences exceed some threshold, 
-#   error exit if differences exceed a different threshold 
+# General purpose comparison script -- compare all variables in a set of files,
+#   write output if differences exceed some threshold,
+#   error exit if differences exceed a different threshold
 #
-# Currently thresholds are specified as absolute differences 
-#    worth revising but could change development practice 
-# Thresholds come from environement variables when set? 
-# 
+# Currently thresholds are specified as absolute differences
+#    worth revising but could change development practice
+# Thresholds come from environement variables when set?
 #
-import sys
-
+#
 import argparse
-import numpy as np
 import os
+import sys
 import warnings
+
+import numpy as np
 import xarray as xr
 
 #
 # Comparing reference and test results
 #
-if __name__ == '__main__':
+if __name__ == "__main__":
     warnings.simplefilter("ignore", xr.SerializationWarning)
 
     parser = argparse.ArgumentParser(
-        description="Compares example output to file in reference directory")
-    parser.add_argument("--ref_dir", type=str,
-                        help="Directory containing reference files")
-    parser.add_argument("--tst_dir", type=str, default=".",
-                        help="Directory contining test values")
-    parser.add_argument("--file_names", type=str, nargs='+', default=[],
-                        help="Name[s] of files to compare")
-    parser.add_argument("--variables", type=str, nargs='+', default=None,
-                        help="Name[s] of files to compare")
-    parser.add_argument("--report_threshold", type=float,
-                        default=os.getenv("REPORTING_THRESHOLD", 0.),
-                        help="Threshold for reporting differences")
-    parser.add_argument("--failure_threshold", type=float,
-                        default=os.getenv("FAILURE_THRESHOLD", 1.e-5),
-                        help="Threshold at which differences cause failure "
-                             "(for continuous integration)")
+        description="Compares example output to file in reference directory"
+    )
+    parser.add_argument(
+        "--ref_dir", type=str, help="Directory containing reference files"
+    )
+    parser.add_argument(
+        "--tst_dir", type=str, default=".", help="Directory contining test values"
+    )
+    parser.add_argument(
+        "--file_names",
+        type=str,
+        nargs="+",
+        default=[],
+        help="Name[s] of files to compare",
+    )
+    parser.add_argument(
+        "--variables",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Name[s] of files to compare",
+    )
+    parser.add_argument(
+        "--report_threshold",
+        type=float,
+        default=os.getenv("REPORTING_THRESHOLD", 0.0),
+        help="Threshold for reporting differences",
+    )
+    parser.add_argument(
+        "--failure_threshold",
+        type=float,
+        default=os.getenv("FAILURE_THRESHOLD", 1.0e-5),
+        help="Threshold at which differences cause failure "
+        "(for continuous integration)",
+    )
     args = parser.parse_args()
 
     tst = xr.open_mfdataset(
-        [os.path.join(args.tst_dir, f) for f in args.file_names],
-        combine='by_coords')
+        [os.path.join(args.tst_dir, f) for f in args.file_names], combine="by_coords"
+    )
     ref = xr.open_mfdataset(
-        [os.path.join(args.ref_dir, f) for f in args.file_names],
-        combine='by_coords')
+        [os.path.join(args.ref_dir, f) for f in args.file_names], combine="by_coords"
+    )
     variables = args.variables if args.variables is not None else tst.variables
 
     failed = False
     for v in variables:
         if np.any(np.isnan(ref.variables[v].values)):
-            raise Exception(
-                v + ": some ref values are missing. That's not right.")
+            raise Exception(v + ": some ref values are missing. That's not right.")
         if np.all(np.isnan(tst.variables[v].values)):
-            raise Exception(
-                v + ": all test values are missing. Were the tests run?")
+            raise Exception(v + ": all test values are missing. Were the tests run?")
         if np.any(np.isnan(tst.variables[v].values)):
-            raise Exception(
-                v + ": some test values are missing. Now that is strange.")
+            raise Exception(v + ": some test values are missing. Now that is strange.")
         #
-        # Reporting 
+        # Reporting
         #
         if not np.allclose(tst[v], ref[v], atol=args.report_threshold, rtol=0):
             diff = abs((tst - ref)[v].values)
             avg = 0.5 * (tst + ref)[v].values
             # Division raises a runtime warning when we divide by zero even if
             # the values in those locations will be ignored.
-            with np.errstate(divide='ignore', invalid='ignore'):
-                frac_diff = np.where(
-                    (avg > 2. * np.finfo(float).eps), diff / avg, 0)
-                print('Variable %s differs (max abs difference: %e; '
-                      'max percent difference: %e%%)' % (
-                          v, diff.max(), 100.0 * frac_diff.max()))
+            with np.errstate(divide="ignore", invalid="ignore"):
+                frac_diff = np.where((avg > 2.0 * np.finfo(float).eps), diff / avg, 0)
+                print(
+                    "Variable %s differs (max abs difference: %e; "
+                    "max percent difference: %e%%)"
+                    % (v, diff.max(), 100.0 * frac_diff.max())
+                )
         else:
-            print('Variable %s: No diffs' % v)
+            print("Variable %s: No diffs" % v)
         #
         # Failure
         #
-        if not np.allclose(tst[v], ref[v], atol=args.failure_threshold,
-                           rtol=0): failed = True
+        if not np.allclose(tst[v], ref[v], atol=args.failure_threshold, rtol=0):
+            failed = True
 
     if failed:
         print("Tests failed")

--- a/examples/rfmip-clear-sky/run-rfmip-examples.py
+++ b/examples/rfmip-clear-sky/run-rfmip-examples.py
@@ -15,39 +15,54 @@ rfmip_dir = "."
 # Code should be run in the rfmip_dir directory
 
 conds_file = os.path.join(
-    os.environ["RRTMGP_DATA"], "examples", "rfmip-clear-sky", "inputs",
-    "multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc")
-lw_gas_coeffs_file = os.path.join(
-    os.environ["RRTMGP_DATA"], "rrtmgp-gas-lw-g256.nc")
-sw_gas_coeffs_file = os.path.join(
-    os.environ["RRTMGP_DATA"], "rrtmgp-gas-sw-g224.nc")
+    os.environ["RRTMGP_DATA"],
+    "examples",
+    "rfmip-clear-sky",
+    "inputs",
+    "multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc",
+)
+lw_gas_coeffs_file = os.path.join(os.environ["RRTMGP_DATA"], "rrtmgp-gas-lw-g256.nc")
+sw_gas_coeffs_file = os.path.join(os.environ["RRTMGP_DATA"], "rrtmgp-gas-sw-g224.nc")
 
 rfmip_lw_exe_name = "./rrtmgp_rfmip_lw"
 rfmip_sw_exe_name = "./rrtmgp_rfmip_sw"
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Runs all-sky examples, resetting output.")
-    parser.add_argument("--run_command", type=str, default="",
-                        help="Prefix ('jsrun' etc.) for running commands. Use "
-                             "quote marks to enclose multi-part commands.")
-    parser.add_argument("--block_size", type=int, default=8,
-                        help="Number of columns to compute at a time. Must be "
-                             "a factor of 1800 (ncol*nexp)")
+        description="Runs all-sky examples, resetting output."
+    )
+    parser.add_argument(
+        "--run_command",
+        type=str,
+        default="",
+        help="Prefix ('jsrun' etc.) for running commands. Use "
+        "quote marks to enclose multi-part commands.",
+    )
+    parser.add_argument(
+        "--block_size",
+        type=int,
+        default=8,
+        help="Number of columns to compute at a time. Must be "
+        "a factor of 1800 (ncol*nexp)",
+    )
 
     args = parser.parse_args()
-    block_size_str = '{0:4d}'.format(args.block_size)
+    block_size_str = "{0:4d}".format(args.block_size)
     if args.run_command:
         print("using the run command")
         rfmip_lw_exe_name = args.run_command + " " + rfmip_lw_exe_name
         rfmip_sw_exe_name = args.run_command + " " + rfmip_sw_exe_name
 
     print(
-        "Running " + rfmip_lw_exe_name + block_size_str + " " +
-        conds_file + " " + lw_gas_coeffs_file)
+        "Running "
+        + rfmip_lw_exe_name
+        + block_size_str
+        + " "
+        + conds_file
+        + " "
+        + lw_gas_coeffs_file
+    )
     # arguments are block size, input conditions, coefficient files, forcing
     # index, physics index
-    subprocess.run(
-        [rfmip_lw_exe_name, block_size_str, conds_file, lw_gas_coeffs_file])
-    subprocess.run(
-        [rfmip_sw_exe_name, block_size_str, conds_file, sw_gas_coeffs_file])
+    subprocess.run([rfmip_lw_exe_name, block_size_str, conds_file, lw_gas_coeffs_file])
+    subprocess.run([rfmip_sw_exe_name, block_size_str, conds_file, sw_gas_coeffs_file])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [tool.isort]
 profile = "black"
 
+[tool.black]
+
 [tool.flake8]
 max-line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.isort]
 profile = "black"
+
+[tool.flake8]
+max-line-length = 88

--- a/tests/validation-plots.py
+++ b/tests/validation-plots.py
@@ -1,15 +1,16 @@
 #! /usr/bin/env python
 
+import argparse
+import urllib.request
+import warnings
+
 import colorcet as cc
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-import urllib.request
-import warnings
 import xarray as xr
 from matplotlib.backends.backend_pdf import PdfPages
 
-import argparse
 
 def mae(diff, col_dim):
     #
@@ -25,23 +26,17 @@ def rms(diff, col_dim):
     return np.sqrt(np.square(diff).mean(dim=col_dim))
 
 
-def make_comparison_plot(variants, labels, reference, vscale, colors,
-                         col_dim="site"):
+def make_comparison_plot(variants, labels, reference, vscale, colors, col_dim="site"):
     #
     # Make a plot comparing differences with respect to reference
     #
     if type(variants) is not list:
-        make_comparison_plot([variants], [labels], reference, vscale, colors,
-                             col_dim)
+        make_comparison_plot([variants], [labels], reference, vscale, colors, col_dim)
     else:
         for i in np.arange(0, len(variants)):
             delta = variants[i] - reference
-            plt.plot(mae(delta, col_dim),
-                     vscale, '-',
-                     color=colors[i], label=labels[i])
-            plt.plot(rms(delta, col_dim),
-                     vscale, '--',
-                     color=colors[i])
+            plt.plot(mae(delta, col_dim), vscale, "-", color=colors[i], label=labels[i])
+            plt.plot(rms(delta, col_dim), vscale, "--", color=colors[i])
         # Reverse vertical ordering
         plt.legend()
         # Reverse vertical ordering
@@ -54,13 +49,25 @@ def construct_lbl_esgf_root(var, esgf_node="llnl"):
     # line-by-line results
     #
     model = "LBLRTM-12-8"
-    prefix = ("http://esgf3.dkrz.de/thredds/fileServer/cmip6/RFMIP/AER/" +
-              model + "/rad-irf/r1i1p1f1/Efx/")
+    prefix = (
+        "http://esgf3.dkrz.de/thredds/fileServer/cmip6/RFMIP/AER/"
+        + model
+        + "/rad-irf/r1i1p1f1/Efx/"
+    )
     if esgf_node == "llnl":
-        prefix = ("http://esgf-data1.llnl.gov/thredds/fileServer/css03_data/"
-                  "CMIP6/RFMIP/AER/" + model + "/rad-irf/r1i1p1f1/Efx/")
-    return (prefix + var + "/gn/v20190514/" + var +
-            "_Efx_" + model + "_rad-irf_r1i1p1f1_gn.nc")
+        prefix = (
+            "http://esgf-data1.llnl.gov/thredds/fileServer/css03_data/"
+            "CMIP6/RFMIP/AER/" + model + "/rad-irf/r1i1p1f1/Efx/"
+        )
+    return (
+        prefix
+        + var
+        + "/gn/v20190514/"
+        + var
+        + "_Efx_"
+        + model
+        + "_rad-irf_r1i1p1f1_gn.nc"
+    )
 
 
 ########################################################################
@@ -69,24 +76,22 @@ def main():
     parser.add_argument(
         "--state_file",
         help="Path to the state information NetCDF file.",
-        default="multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc"
+        default="multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc",
     )
     parser.add_argument(
         "--lw_vars_file",
-        help="Path to the LW results file", 
-        default="lw_flux_variants.nc"
-
+        help="Path to the LW results file",
+        default="lw_flux_variants.nc",
     )
     parser.add_argument(
         "--sw_vars_file",
-        help="Path to the SW results file", 
-        default="sw_flux_variants.nc"
-
+        help="Path to the SW results file",
+        default="sw_flux_variants.nc",
     )
     parser.add_argument(
         "--output_pdf",
         help="Path to the output PDF file for validation plots.",
-        default="validation-figures.pdf"
+        default="validation-figures.pdf",
     )
     args = parser.parse_args()
 
@@ -105,17 +110,17 @@ def main():
     for v in fluxes:
         try:
             try:
-                urllib.request.urlretrieve(construct_lbl_esgf_root(v),
-                                           v + lbl_suffix)
+                urllib.request.urlretrieve(construct_lbl_esgf_root(v), v + lbl_suffix)
             except:
                 urllib.request.urlretrieve(
-                    construct_lbl_esgf_root(v, esgf_node="dkrz"),
-                    v + lbl_suffix)
+                    construct_lbl_esgf_root(v, esgf_node="dkrz"), v + lbl_suffix
+                )
         except:
             raise Exception("Failed to download {0}".format(v + lbl_suffix))
 
-    lbl = xr.open_mfdataset([v + lbl_suffix for v in fluxes],
-                            combine="by_coords").sel(expt=0)
+    lbl = xr.open_mfdataset([v + lbl_suffix for v in fluxes], combine="by_coords").sel(
+        expt=0
+    )
 
     #
     # Open the test results
@@ -125,9 +130,10 @@ def main():
     # Does the flux plus the Jacobian equal a calculation with perturbed surface
     # temperature?
     #
-    gp['lw_flux_up_from_deriv'] = gp.lw_flux_up + gp.lw_jaco_up
+    gp["lw_flux_up_from_deriv"] = gp.lw_flux_up + gp.lw_jaco_up
     gp.lw_flux_up_from_deriv.attrs = {
-        "description": "LW flux up, surface T+1K, computed from Jacobian"}
+        "description": "LW flux up, surface T+1K, computed from Jacobian"
+    }
     ########################################################################
     #
     # The RFMIP cases are on an irregular pressure grid so we can't compute
@@ -137,16 +143,28 @@ def main():
     #
     plevs = np.arange(0, lbl.plev.max(), 1000)
     plevs[0] = lbl.plev.min().values
-    plev = xr.DataArray(plevs, dims=['plev'], coords={'plev': plevs})
-    lbli = xr.concat([lbl.sel(site=i).reset_coords().swap_dims(
-        {"level": "plev"}).interp(plev=plev) for i in
-                      np.arange(0, lbl.site.size)], dim='site')
+    plev = xr.DataArray(plevs, dims=["plev"], coords={"plev": plevs})
+    lbli = xr.concat(
+        [
+            lbl.sel(site=i)
+            .reset_coords()
+            .swap_dims({"level": "plev"})
+            .interp(plev=plev)
+            for i in np.arange(0, lbl.site.size)
+        ],
+        dim="site",
+    )
     gpi = xr.concat(
-        [gp.sel(site=i).rename(
-            {"pres_level": "plev"}).reset_coords().swap_dims(
-            {"level": "plev"}).interp(plev=plev)
-         for i in np.arange(0, gp.site.size)],
-        dim='site')
+        [
+            gp.sel(site=i)
+            .rename({"pres_level": "plev"})
+            .reset_coords()
+            .swap_dims({"level": "plev"})
+            .interp(plev=plev)
+            for i in np.arange(0, gp.site.size)
+        ],
+        dim="site",
+    )
 
     cols = cc.glasbey_dark
     mpl.rcParams["legend.frameon"] = False
@@ -160,31 +178,57 @@ def main():
         #
         # Accuracy - 3-angle and single-angle
         #
-        variants = [[gpi.lw_flux_dn, gpi.lw_flux_dn_alt, gpi.lw_flux_dn_optang,
-                     gpi.lw_flux_dn_alt_oa, gpi.lw_flux_dn_3ang,
-                     gpi.lw_flux_dn_2str, gpi.lw_flux_dn_1rescl],
-                    [gpi.lw_flux_up, gpi.lw_flux_up_alt, gpi.lw_flux_up_optang,
-                     gpi.lw_flux_up_alt_oa, gpi.lw_flux_up_3ang,
-                     gpi.lw_flux_up_2str, gpi.lw_flux_up_1rescl],
-                    [gpi.lw_flux_net,
-                     gpi.lw_flux_net_alt,
-                     gpi.lw_flux_dn_optang - gpi.lw_flux_up_optang,
-                     gpi.lw_flux_dn_alt_oa - gpi.lw_flux_up_alt_oa,
-                     gpi.lw_flux_dn_3ang - gpi.lw_flux_up_3ang,
-                     gpi.lw_flux_dn_2str - gpi.lw_flux_up_2str,
-                     gpi.lw_flux_dn_1rescl - gpi.lw_flux_up_1rescl]]
+        variants = [
+            [
+                gpi.lw_flux_dn,
+                gpi.lw_flux_dn_alt,
+                gpi.lw_flux_dn_optang,
+                gpi.lw_flux_dn_alt_oa,
+                gpi.lw_flux_dn_3ang,
+                gpi.lw_flux_dn_2str,
+                gpi.lw_flux_dn_1rescl,
+            ],
+            [
+                gpi.lw_flux_up,
+                gpi.lw_flux_up_alt,
+                gpi.lw_flux_up_optang,
+                gpi.lw_flux_up_alt_oa,
+                gpi.lw_flux_up_3ang,
+                gpi.lw_flux_up_2str,
+                gpi.lw_flux_up_1rescl,
+            ],
+            [
+                gpi.lw_flux_net,
+                gpi.lw_flux_net_alt,
+                gpi.lw_flux_dn_optang - gpi.lw_flux_up_optang,
+                gpi.lw_flux_dn_alt_oa - gpi.lw_flux_up_alt_oa,
+                gpi.lw_flux_dn_3ang - gpi.lw_flux_up_3ang,
+                gpi.lw_flux_dn_2str - gpi.lw_flux_up_2str,
+                gpi.lw_flux_dn_1rescl - gpi.lw_flux_up_1rescl,
+            ],
+        ]
         refs = [lbli.rld, lbli.rlu, lbli.rld - lbli.rlu]
-        titles = ["Accuracy wrt LBLRTM: LW down", "Accuracy wrt LBLRTM: LW up",
-                  "Accuracy: LW net"]
+        titles = [
+            "Accuracy wrt LBLRTM: LW down",
+            "Accuracy wrt LBLRTM: LW up",
+            "Accuracy: LW net",
+        ]
         for v, r, t in zip(variants, refs, titles):
-            make_comparison_plot(v,
-                                 labels=["default", "fewer-g-points",
-                                         "optimal-angle",
-                                         "fewer points + optimal-angle",
-                                         "3-angle", "2-stream", "rescaled"],
-                                 reference=r,
-                                 vscale=plev / 100.,
-                                 colors=cols)
+            make_comparison_plot(
+                v,
+                labels=[
+                    "default",
+                    "fewer-g-points",
+                    "optimal-angle",
+                    "fewer points + optimal-angle",
+                    "3-angle",
+                    "2-stream",
+                    "rescaled",
+                ],
+                reference=r,
+                vscale=plev / 100.0,
+                colors=cols,
+            )
             plt.ylabel("Pressure (Pa)")
             plt.xlabel("Error (W/m$^2$), solid=mean, dash=RMS")
             plt.title(t)
@@ -198,16 +242,20 @@ def main():
         # Using scattering representations of optical properties to do a
         # no-scattering calculation
         #
-        variants = [[gpi.lw_flux_dn_notlev, gpi.lw_flux_dn_2str],
-                    [gpi.lw_flux_up_notlev, gpi.lw_flux_up_2str]]
+        variants = [
+            [gpi.lw_flux_dn_notlev, gpi.lw_flux_dn_2str],
+            [gpi.lw_flux_up_notlev, gpi.lw_flux_up_2str],
+        ]
         refs = [gpi.lw_flux_dn, gpi.lw_flux_up]
         titles = ["Variants: LW down", "Variants: LW up"]
         for v, r, t in zip(variants, refs, titles):
-            make_comparison_plot(v,
-                                 labels=["no-tlev", "2str"],
-                                 reference=r,
-                                 vscale=plev / 100.,
-                                 colors=cols)
+            make_comparison_plot(
+                v,
+                labels=["no-tlev", "2str"],
+                reference=r,
+                vscale=plev / 100.0,
+                colors=cols,
+            )
             plt.ylabel("Pressure (Pa)")
             plt.xlabel("Difference (W/m$^2$), solid=mean, dash=RMS")
             plt.title(t)
@@ -221,16 +269,20 @@ def main():
         #
         # Accuracy comparison
         #
-        variants = [[gpi.sw_flux_dn, gpi.sw_flux_dn_alt],
-                    [gpi.sw_flux_up, gpi.sw_flux_up_alt]]
+        variants = [
+            [gpi.sw_flux_dn, gpi.sw_flux_dn_alt],
+            [gpi.sw_flux_up, gpi.sw_flux_up_alt],
+        ]
         refs = [lbli.rsd, lbli.rsu]
         titles = ["Accuracy: SW down", "Accuracy: SW up"]
         for v, r, t in zip(variants, refs, titles):
-            make_comparison_plot(v,
-                                 labels=["default", "fewer-g-points"],
-                                 reference=r,
-                                 vscale=plev / 100.,
-                                 colors=cols)
+            make_comparison_plot(
+                v,
+                labels=["default", "fewer-g-points"],
+                reference=r,
+                vscale=plev / 100.0,
+                colors=cols,
+            )
             plt.ylabel("Pressure (Pa)")
             plt.xlabel("Error (W/m$^2$), solid=mean, dash=RMS")
             plt.title(t)
@@ -238,5 +290,5 @@ def main():
             plt.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/validation-plots.py
+++ b/tests/validation-plots.py
@@ -111,11 +111,11 @@ def main():
         try:
             try:
                 urllib.request.urlretrieve(construct_lbl_esgf_root(v), v + lbl_suffix)
-            except:
+            except Exception:
                 urllib.request.urlretrieve(
                     construct_lbl_esgf_root(v, esgf_node="dkrz"), v + lbl_suffix
                 )
-        except:
+        except Exception:
             raise Exception("Failed to download {0}".format(v + lbl_suffix))
 
     lbl = xr.open_mfdataset([v + lbl_suffix for v in fluxes], combine="by_coords").sel(


### PR DESCRIPTION
This is probably for the Python team to review:
1. Format all Python files with `isort` and `black`.
2. Address (naively) issues identified by `flake8`.
3. Extend the `pre-commit` configuration with respective hooks.

This should not be merged as is. First, we need to agree on the formatting (e.g. the line length, which is currently set to `black`'s default `88`). Then we will need to apply the formatting in a different PR, merge it to `develop`, update `.git-blame-ignore-revs` in this PR accordingly, and only then merge this PR.

Depends on #338.