### PR TITLE
Support NEC Aurora compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,17 +20,24 @@ set_property(CACHE KERNEL_MODE PROPERTY STRINGS ${PREFERRED_KERNEL_MODES})
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
+# CMake does not support the NEC compiler and usually mistakes it for GNU:
+if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
+  # Check whether the Fortran compiler in use is NEC:
+  include(CheckCompilerIsNEC)
+  check_compiler_is_nec(RTE_RRTMGP_Fortran_is_NEC Fortran)
+endif()
+
 # GNUInstallDirs issues a warning if CMAKE_SIZEOF_VOID_P is not defined, which
-# is the case with NAG. One way to circumvent that is to enable C language for
-# the project:
-if(CMAKE_Fortran_COMPILER_ID STREQUAL NAG)
+# is the case with NAG and NEC. One way to circumvent that is to enable C
+# language for the project:
+if(CMAKE_Fortran_COMPILER_ID STREQUAL NAG OR RTE_RRTMGP_Fortran_is_NEC)
   enable_language(C)
 endif()
 include(GNUInstallDirs)
 
-add_compile_options(
-  $<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-ffree-line-length-none>
-)
+if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU AND NOT RTE_RRTMGP_Fortran_is_NEC)
+  add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>)
+endif()
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules)
 

--- a/cmake/CheckCompilerIsNEC.cmake
+++ b/cmake/CheckCompilerIsNEC.cmake
@@ -1,0 +1,65 @@
+# ~~~
+# check_compiler_is_nec(<variable> <language>)
+# ~~~
+# Checks whether the <language> compiler in use is actually the NEC one (CMake
+# does not support NEC compiler yet and usually mistakes it for GNU). Sets the
+# internal cache <variable> to the result of the check. The requested <language>
+# must be enabled. Supported languages are C, CXX and Fortran.
+#
+function(check_compiler_is_nec var lang)
+  if(DEFINED ${var})
+    return()
+  endif()
+
+  get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+  if(NOT ${lang} IN_LIST languages)
+    message(FATAL_ERROR "Language ${lang} is not enabled")
+  endif()
+
+  if(${lang} STREQUAL "C")
+    include(CheckSymbolExists)
+    set(CMAKE_REQUIRED_QUIET 1)
+    check_symbol_exists(__NEC__ "" ${var})
+  elseif(${lang} STREQUAL "CXX")
+    include(CheckCXXSymbolExists)
+    set(CMAKE_REQUIRED_QUIET 1)
+    check_cxx_symbol_exists(__NEC__ "" ${var})
+  elseif(${lang} STREQUAL "Fortran")
+    set(check_source_file
+        "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.F90"
+    )
+    file(
+      WRITE "${check_source_file}"
+      "      program main
+      implicit none
+#ifdef __NEC__
+      integer a
+#else
+      choke me
+#endif
+#ifndef __NEC__
+      choke me
+#else
+      integer b
+#endif
+      a = 4
+      b = 2
+      end
+"
+    )
+    try_compile(${var} "${PROJECT_BINARY_DIR}" "${check_source_file}")
+  else()
+    message(FATAL_ERROR "Language ${lang} is not supported")
+  endif()
+
+  if(${var})
+    set(${var} TRUE)
+  else()
+    set(${var} FALSE)
+  endif()
+
+  set(${var}
+      "${${var}}"
+      CACHE INTERNAL "Whether the ${lang} compiler is NEC"
+  )
+endfunction()


### PR DESCRIPTION
This updates the CMake scripting to support the [`NEC SX-Aurora TSUBASA Compiler`](https://www.nec.com/en/global/solutions/hpc/sx/tools.html) (a.k.a `nfort`).

With `nfort 5.3.0`, all tests pass with `-DCMAKE_BUILD_TYPE=Release -DRTE_ENABLE_SP=OFF` (i.e. `-O3`). With `-DRTE_ENABLE_SP=ON`, all tests pass only with `-O1`. Any higher optimization level makes `check_equivalence_sw_g112` fail with:
```
   Changing TSI fails
   halving/doubling fails
   Incrementing with 1scl fails
   Incrementing with 2str fails
   Incrementing with nstr fails
```