### PR TITLE
Ice sizes are diameters, not radii

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ exit(tuple(map(int, xarray.__version__.split('.'))) < (0, 12, 2))"
     ExternalProject_Add(
       rrtmgp-data
       GIT_REPOSITORY https://github.com/earth-system-radiation/rrtmgp-data.git
-      GIT_TAG "v1.8.2"
+      GIT_TAG "develop"
       GIT_SHALLOW True
       EXCLUDE_FROM_ALL True
       PREFIX rrtmgp-data-cmake

--- a/examples/all-sky/mo_load_cloud_coefficients.F90
+++ b/examples/all-sky/mo_load_cloud_coefficients.F90
@@ -33,9 +33,9 @@ contains
     real(wp) :: radliq_lwr          ! liquid particle size lower bound for interpolation
     real(wp) :: radliq_upr          ! liquid particle size upper bound for interpolation
     real(wp) :: radliq_fac          ! constant for calculating interpolation indices for liquid
-    real(wp) :: radice_lwr          ! ice particle size lower bound for interpolation
-    real(wp) :: radice_upr          ! ice particle size upper bound for interpolation
-    real(wp) :: radice_fac          ! constant for calculating interpolation indices for ice
+    real(wp) :: diamice_lwr          ! ice particle size lower bound for interpolation
+    real(wp) :: diamice_upr          ! ice particle size upper bound for interpolation
+    real(wp) :: diam_icefac          ! constant for calculating interpolation indices for ice
     ! LUT coefficients
     real(wp), dimension(:,:),   allocatable :: lut_extliq   ! extinction: liquid
     real(wp), dimension(:,:),   allocatable :: lut_ssaliq   ! single scattering albedo: liquid
@@ -60,8 +60,8 @@ contains
     ! Read LUT constants
     radliq_lwr = read_field(ncid, 'radliq_lwr')
     radliq_upr = read_field(ncid, 'radliq_upr')
-    radice_lwr = read_field(ncid, 'radice_lwr')
-    radice_upr = read_field(ncid, 'radice_upr')
+    diamice_lwr = read_field(ncid, 'diamice_lwr')
+    diamice_upr = read_field(ncid, 'diamice_upr')
 
     ! Allocate cloud property lookup table input arrays
     allocate(lut_extliq(nsize_liq, nband), &
@@ -82,7 +82,7 @@ contains
     ncid = nf90_close(ncid)
     call stop_on_err(cloud_spec%load(band_lims_wvn,                      &
                                      radliq_lwr, radliq_upr,             &
-                                     radice_lwr, radice_upr,             &
+                                     diamice_lwr, diamice_upr,             &
                                      lut_extliq, lut_ssaliq, lut_asyliq, &
                                      lut_extice, lut_ssaice, lut_asyice))
   end subroutine load_cld_lutcoeff


### PR DESCRIPTION
Tables in the RRTMGP data, and code here, suggested that liquid and ice cloud optical properties were tabulated as a function of radius; in fact ice clouds are tabulated vs. diameter.

Addresses #309. Originally #311. 