### PR TITLE
Added to aways use cbool

### DIFF
--- a/rte-kernels/api/rte_types.h
+++ b/rte-kernels/api/rte_types.h
@@ -16,11 +16,7 @@ This header files C-compatible Boolean and floating point types (see mo_rte_type
 */
 #pragma once
 
-#ifdef RTE_USE_CBOOL
 using Bool = signed char;
-#else
-using Bool = int;
-#endif
 
 #ifdef RTE_USE_SP
 using Float = float;


### PR DESCRIPTION
Removed the option for using something else than cbool