### PR TITLE
Fix intent spec

### DIFF
--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -370,7 +370,7 @@ contains
     ! local variables
     real(wp) :: tau_major(ngpt) ! major species optical depth
     ! local index
-    integer :: icol, igpt, ilay, iflav, ibnd, itropo
+    integer :: icol, ilay, iflav, ibnd, itropo
     integer :: gptS, gptE
 
     ! optical depth calculation for major species
@@ -388,9 +388,7 @@ contains
                                  fmajor(:,:,:,icol,ilay,iflav), kmajor,                          &
                                  band_lims_gpt(1, ibnd), band_lims_gpt(2, ibnd),                 &
                                  jeta(:,icol,ilay,iflav), jtemp(icol,ilay),jpress(icol,ilay)+itropo, tau_major)
-          do igpt = gptS, gptE
-            tau(icol,ilay,igpt) = tau(icol,ilay,igpt) + tau_major(igpt)
-          end do
+          tau(icol,ilay,gptS:gptE) = tau(icol,ilay,gptS:gptE) + tau_major(gptS:gptE)
         end do
       end do
     end do
@@ -609,7 +607,7 @@ contains
     integer  :: ilay, icol, igpt, ibnd, itropo, iflav
     integer  :: gptS, gptE
     real(wp), dimension(2), parameter :: one = [1._wp, 1._wp]
-    real(wp) :: pfrac          (ngpt, ncol,nlay)
+    real(wp) :: pfrac          (ncol,nlay  ,ngpt)
     real(wp) :: planck_function(ncol,nlay+1,nbnd)
     ! -----------------
 
@@ -627,7 +625,7 @@ contains
                           one, fmajor(:,:,:,icol,ilay,iflav), pfracin, &
                           band_lims_gpt(1, ibnd), band_lims_gpt(2, ibnd),                 &
                           jeta(:,icol,ilay,iflav), jtemp(icol,ilay),jpress(icol,ilay)+itropo, &
-                          pfrac(:, icol,ilay))
+                          pfrac(icol,ilay,:))
         end do ! column
       end do   ! layer
     end do     ! band
@@ -646,8 +644,8 @@ contains
         gptS = band_lims_gpt(1, ibnd)
         gptE = band_lims_gpt(2, ibnd)
         do igpt = gptS, gptE
-            sfc_src(icol,igpt) = pfrac(igpt,icol,sfc_lay) * planck_function(icol,1,ibnd)
-            sfc_source_Jac(icol, igpt) = pfrac(igpt,icol,sfc_lay) * &
+            sfc_src(icol,igpt) = pfrac(icol,sfc_lay,igpt) * planck_function(icol,1,ibnd)
+            sfc_source_Jac(icol, igpt) = pfrac(icol,sfc_lay,igpt) * &
                                 (planck_function(icol, 2, ibnd) - planck_function(icol,1,ibnd))
         end do
       end do
@@ -666,10 +664,10 @@ contains
     do ibnd = 1, nbnd
       gptS = band_lims_gpt(1, ibnd)
       gptE = band_lims_gpt(2, ibnd)
-      do ilay = 1, nlay
-        do icol = 1, ncol
-          do igpt = gptS, gptE
-            lay_src(icol,ilay,igpt) = pfrac(igpt,icol,ilay) * planck_function(icol,ilay,ibnd)
+      do igpt = gptS, gptE
+        do ilay = 1, nlay
+          do icol = 1, ncol
+            lay_src(icol,ilay,igpt) = pfrac(icol,ilay,igpt) * planck_function(icol,ilay,ibnd)
           end do
         end do
       end do
@@ -693,17 +691,17 @@ contains
       gptE = band_lims_gpt(2, ibnd)
       do igpt = gptS, gptE
         do icol = 1, ncol
-          lev_src(icol,     1,igpt) = pfrac(igpt,icol,   1) * planck_function(icol,     1,ibnd)
+          lev_src(icol,     1,igpt) = pfrac(icol,   1,igpt) * planck_function(icol,     1,ibnd)
         end do
         do ilay = 2, nlay
           do icol = 1, ncol
-            lev_src(icol,ilay,igpt) = sqrt(pfrac(igpt,icol,ilay-1) *  &
-                                           pfrac(igpt,icol,ilay)) &
+            lev_src(icol,ilay,igpt) = sqrt(pfrac(icol,ilay-1, igpt) *  &
+                                           pfrac(icol,ilay,   igpt)) &
                                                             * planck_function(icol,ilay,  ibnd)
           end do
         end do
         do icol = 1, ncol
-          lev_src(icol,nlay+1,igpt) = pfrac(igpt,icol,nlay) * planck_function(icol,nlay+1,ibnd)
+          lev_src(icol,nlay+1,igpt) = pfrac(icol,nlay,igpt) * planck_function(icol,nlay+1,ibnd)
         end do
       end do
     end do
@@ -771,7 +769,7 @@ contains
     integer, dimension(2),       intent(in) :: jeta ! interpolation index for binary species parameter (eta)
     integer,                     intent(in) :: jtemp ! interpolation index for temperature
     integer,                     intent(in) :: jpress ! interpolation index for pressure
-    real(wp), dimension(ngpt), intent(out)          :: res ! the result
+    real(wp), dimension(:), intent(out)          :: res ! the result
 
     ! Local variable
     integer :: igpt, jeta1, jeta2

--- a/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+++ b/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
@@ -769,7 +769,7 @@ contains
     integer, dimension(2),       intent(in) :: jeta ! interpolation index for binary species parameter (eta)
     integer,                     intent(in) :: jtemp ! interpolation index for temperature
     integer,                     intent(in) :: jpress ! interpolation index for pressure
-    real(wp), dimension(:), intent(out)          :: res ! the result
+    real(wp), dimension(:), intent(inout)          :: res ! the result
 
     ! Local variable
     integer :: igpt, jeta1, jeta2


### PR DESCRIPTION
The initialization of pfrac within mo_gas_optics_rrtmgp_kernels::compute_Planck_source did not account for the overlap of different passes, which requires the pre-existing values to remain in place.
This MR fixes that problem and also reverts a dimension switch that locally leads to better data access but screws performance in the overall picture, where icol should always be the first dimension.

See #370 for the reason of this PR.