### PR TITLE
Avoid underflow at initialization

### DIFF
--- a/rte-frontend/mo_rte_lw.F90
+++ b/rte-frontend/mo_rte_lw.F90
@@ -129,22 +129,25 @@ contains
     !   Values from Table 1, R. J. Hogan 2023, doi:10.1002/qj.4598
     !
     integer,  parameter :: max_gauss_pts = 4
+    real(wp), dimension(max_gauss_pts, max_gauss_pts) :: gauss_Ds
     real(wp), parameter,                         &
       dimension(max_gauss_pts, max_gauss_pts) :: &
         ! 
         ! Values provided are for mu = cos(theta); we require the inverse
         !
-        gauss_Ds  = 1._wp / & 
-                    RESHAPE([0.6096748751_wp, huge(1._wp)    , huge(1._wp)    , huge(1._wp),      &  
-                             0.2509907356_wp, 0.7908473988_wp, huge(1._wp)    , huge(1._wp),      &
-                             0.1024922169_wp, 0.4417960320_wp, 0.8633751621_wp, huge(1._wp),      &
-                             0.0454586727_wp, 0.2322334416_wp, 0.5740198775_wp, 0.9030775973_wp], &
-                            [max_gauss_pts, max_gauss_pts]),              &
         gauss_wts = RESHAPE([1._wp,           0._wp,           0._wp,           0._wp, &
                              0.2300253764_wp, 0.7699746236_wp, 0._wp,           0._wp, &
                              0.0437820218_wp, 0.3875796738_wp, 0.5686383044_wp, 0._wp, &
                              0.0092068785_wp, 0.1285704278_wp, 0.4323381850_wp, 0.4298845087_wp], &
                              [max_gauss_pts, max_gauss_pts])
+    gauss_Ds  = 1._wp / &
+                    RESHAPE([0.6096748751_wp, 1._wp,           1._wp,           1._wp, &
+                             0.2509907356_wp, 0.7908473988_wp, 1._wp,           1._wp, &
+                             0.1024922169_wp, 0.4417960320_wp, 0.8633751621_wp, 1._wp, &
+                             0.0454586727_wp, 0.2322334416_wp, 0.5740198775_wp, 0.9030775973_wp], &
+                             [max_gauss_pts, max_gauss_pts])
+    where(gauss_wts==0._wp) gauss_Ds = 0._wp
+
     ! ------------------------------------------------------------------------------------
     ncol  = optical_props%get_ncol()
     nlay  = optical_props%get_nlay()

--- a/rte-frontend/mo_rte_lw.F90
+++ b/rte-frontend/mo_rte_lw.F90
@@ -135,9 +135,9 @@ contains
         ! Values provided are for mu = cos(theta); we require the inverse
         !
         gauss_Ds  = 1._wp / & 
-                    RESHAPE([0.6096748751_wp, 1._wp,           1._wp,           1._wp, &
-                             0.2509907356_wp, 0.7908473988_wp, 1._wp,           1._wp, &
-                             0.1024922169_wp, 0.4417960320_wp, 0.8633751621_wp, 1._wp, &
+                    RESHAPE([0.6096748751_wp, huge(1._wp)    , huge(1._wp)    , huge(1._wp),      &  
+                             0.2509907356_wp, 0.7908473988_wp, huge(1._wp)    , huge(1._wp),      &
+                             0.1024922169_wp, 0.4417960320_wp, 0.8633751621_wp, huge(1._wp),      &
                              0.0454586727_wp, 0.2322334416_wp, 0.5740198775_wp, 0.9030775973_wp], &
                             [max_gauss_pts, max_gauss_pts]),              &
         gauss_wts = RESHAPE([1._wp,           0._wp,           0._wp,           0._wp, &
@@ -145,7 +145,6 @@ contains
                              0.0437820218_wp, 0.3875796738_wp, 0.5686383044_wp, 0._wp, &
                              0.0092068785_wp, 0.1285704278_wp, 0.4323381850_wp, 0.4298845087_wp], &
                              [max_gauss_pts, max_gauss_pts])
-    where(gauss_wts==0._wp) gauss_Ds=0._wp
     ! ------------------------------------------------------------------------------------
     ncol  = optical_props%get_ncol()
     nlay  = optical_props%get_nlay()

--- a/rte-frontend/mo_rte_lw.F90
+++ b/rte-frontend/mo_rte_lw.F90
@@ -135,9 +135,9 @@ contains
         ! Values provided are for mu = cos(theta); we require the inverse
         !
         gauss_Ds  = 1._wp / & 
-                    RESHAPE([0.6096748751_wp, huge(1._wp)    , huge(1._wp)    , huge(1._wp),      &  
-                             0.2509907356_wp, 0.7908473988_wp, huge(1._wp)    , huge(1._wp),      &
-                             0.1024922169_wp, 0.4417960320_wp, 0.8633751621_wp, huge(1._wp),      &
+                    RESHAPE([0.6096748751_wp, 1._wp,           1._wp,           1._wp, &
+                             0.2509907356_wp, 0.7908473988_wp, 1._wp,           1._wp, &
+                             0.1024922169_wp, 0.4417960320_wp, 0.8633751621_wp, 1._wp, &
                              0.0454586727_wp, 0.2322334416_wp, 0.5740198775_wp, 0.9030775973_wp], &
                             [max_gauss_pts, max_gauss_pts]),              &
         gauss_wts = RESHAPE([1._wp,           0._wp,           0._wp,           0._wp, &
@@ -145,6 +145,7 @@ contains
                              0.0437820218_wp, 0.3875796738_wp, 0.5686383044_wp, 0._wp, &
                              0.0092068785_wp, 0.1285704278_wp, 0.4323381850_wp, 0.4298845087_wp], &
                              [max_gauss_pts, max_gauss_pts])
+    where(gauss_wts==0._wp) gauss_Ds=0._wp
     ! ------------------------------------------------------------------------------------
     ncol  = optical_props%get_ncol()
     nlay  = optical_props%get_nlay()


### PR DESCRIPTION
The CCPP recently updated tom using rte-rrtmgp v1.8 and we encounter the following compilation warning in the UFS Weather Model:

RRTMGP/rte-rrtmgp/rte-frontend/mo_rte_lw.F90(137): warning #7920: The value was too small when converting to REAL(KIND=4); the result is in the denormalized range.                                                                    
        gauss_Ds  = 1._wp / &  
    
This PR breaks the declaration into two steps to avoid dividing by a really huuge number.

More discussion can be found [here](https://github.com/ufs-community/ccpp-physics/issues/322).

@RobertPincus For some reason I can't edit the PR title, nor did I create this title. ?!?