### PR TITLE
Update default triangle_params_def_lw values

### DIFF
--- a/ssm/mo_optics_ssm.F90
+++ b/ssm/mo_optics_ssm.F90
@@ -68,11 +68,11 @@ module mo_optics_ssm
     [(1000._wp + (i-1) * (45000._wp - 1000._wp) / (nnu_def - 1), i = 1, nnu_def)] ! Default wavenumber array, SW
 
   ! Default spectoscopic params
-  real(wp), dimension(4,4), parameter :: triangle_params_def_lw = reshape( &
+  real(wp), dimension(3,4), parameter :: triangle_params_def_lw = reshape( &
     [1._wp, 282._wp,    0._wp, 64._wp,  &
      1._wp,  24._wp, 1600._wp, 52._wp,  &
      2._wp, 110._wp,  667._wp, 12._wp], &
-    shape = [4, 4], order = [2, 1])
+    shape = [3, 4], order = [2, 1])
 
   character(len=32), dimension(2), parameter :: gas_names_def_lw = [character(32) :: "h2o", "co2"]
 


### PR DESCRIPTION
You only need two entries in triangle_params to fit H2O line absorption. Previously I was trying to fit the median-filtered H2O line absorption using three triangles, but that's unnecessary. I've re-run using a fit like: 

$$
\kappa = \kappa_{1} \exp\left(-\frac{|\nu|}{l_{1}}\right) + \kappa_{2} \exp\left(-\frac{|\nu - \nu_{2}|}{l_{2}}\right)
$$

where $\nu_{2}=1600 cm^{-1}$. 

The results from #379 are nearly identical, because you only need two triangles to fit this H2O line behavior (below)

<img width="2576" height="1181" alt="image" src="https://github.com/user-attachments/assets/f97471e8-2159-4028-8ba4-105bdf62aad2" />

