### PR TITLE
Multi-lines OpenMP typo fix

### DIFF
--- a/rrtmgp/frontend/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp/frontend/mo_gas_optics_rrtmgp.F90
@@ -1756,7 +1756,7 @@ contains
       !$acc           delete(this%idx_minor_upper, this%idx_minor_scaling_upper)  &
       !$acc           delete(this%kminor_start_upper, this%kminor_upper)
       !$omp target exit data map(release:this%gas_names, this%vmr_ref, this%flavor) &
-      !$omp map(release:this%press_ref, this%press_ref_log, this%temp_ref)
+      !$omp map(release:this%press_ref, this%press_ref_log, this%temp_ref) &
       !$omp map(release:this%gpoint_flavor, this%kmajor)  &
       !$omp map(release:this%minor_limits_gpt_lower) &
       !$omp map(release:this%minor_scales_with_density_lower, this%scale_by_complement_lower)  &
@@ -1790,7 +1790,7 @@ contains
       if(allocated(this%solar_source)) then
         !$acc exit data delete(this%solar_source, this%solar_source_quiet) &
         !$acc           delete(this%solar_source_facular,this%solar_source_sunspot)
-        !$omp target exit data map(release:this%solar_source, this%solar_source_quiet)
+        !$omp target exit data map(release:this%solar_source, this%solar_source_quiet) &
         !$omp map(release:this%solar_source_facular,this%solar_source_sunspot)
         deallocate(this%solar_source, &
                    this%solar_source_quiet, this%solar_source_facular, this%solar_source_sunspot)


### PR DESCRIPTION
Added some missing '&' in OpenMP directives which prevented compilation with the Cray compiler