### PR TITLE
Effective radius vs. diameter naming fix

### DIFF
--- a/examples/all-sky/rrtmgp_allsky.F90
+++ b/examples/all-sky/rrtmgp_allsky.F90
@@ -653,7 +653,7 @@ contains
         lwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) .and. t_lay(icol,ilay) > 263._wp)
         iwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) .and. t_lay(icol,ilay) < 273._wp)
         rel(icol,ilay) = merge(rel_val, 0._wp, lwp(icol,ilay) > 0._wp)
-        rei(icol,ilay) = merge(dei_val, 0._wp, iwp(icol,ilay) > 0._wp)
+        dei(icol,ilay) = merge(dei_val, 0._wp, iwp(icol,ilay) > 0._wp)
       end do
     end do
     !$acc exit data delete(cloud_mask)

--- a/examples/all-sky/rrtmgp_allsky.F90
+++ b/examples/all-sky/rrtmgp_allsky.F90
@@ -57,7 +57,7 @@ program rte_rrtmgp_allsky
   !
   ! Clouds
   !
-  real(wp), allocatable, dimension(:,:) :: lwp, iwp, rel, rei
+  real(wp), allocatable, dimension(:,:) :: lwp, iwp, rel, dei
   logical,  allocatable, dimension(:,:) :: cloud_mask
   !
   ! Aerosols
@@ -340,9 +340,9 @@ program rte_rrtmgp_allsky
     if(do_clouds) then
       select type (gas_optics)
         type is (ty_gas_optics_rrtmgp)
-          call stop_on_err(cloud_optics%cloud_optics(lwp, iwp, rel, rei, clouds))
+          call stop_on_err(cloud_optics%cloud_optics(lwp, iwp, rel, dei, clouds))
         type is (ty_optics_ssm)
-          call stop_on_err(  gas_optics%cloud_optics(lwp, iwp, rel, rei, clouds))
+          call stop_on_err(  gas_optics%cloud_optics(lwp, iwp, rel, dei, clouds))
       end select
     end if
 
@@ -441,9 +441,9 @@ program rte_rrtmgp_allsky
 #ifndef _CRAYFTN
     ! ACCWA cloud_mask is already deallocated, Cray does not currently allow
     ! ACCWA delete in that case
-    !$acc        exit data delete(     cloud_mask, lwp, iwp, rel, rei)
+    !$acc        exit data delete(     cloud_mask, lwp, iwp, rel, dei)
 #endif
-    !$omp target exit data map(release:cloud_mask, lwp, iwp, rel, rei)
+    !$omp target exit data map(release:cloud_mask, lwp, iwp, rel, dei)
     select type(clouds)
       class is (ty_optical_props_1scl)
         !$acc        exit data delete     (clouds%tau, clouds)
@@ -589,7 +589,7 @@ contains
   !
   subroutine compute_clouds
 
-    real(wp) :: rel_val, rei_val
+    real(wp) :: rel_val, dei_val
     !
     ! Variable and memory allocation
     !
@@ -624,9 +624,9 @@ contains
     ! Cloud physical properties
     !
     allocate(lwp(ncol,nlay), iwp(ncol,nlay), &
-             rel(ncol,nlay), rei(ncol,nlay), cloud_mask(ncol,nlay))
-    !$acc enter        data create(   cloud_mask, lwp, iwp, rel, rei)
-    !$omp target enter data map(alloc:cloud_mask, lwp, iwp, rel, rei)
+             rel(ncol,nlay), dei(ncol,nlay), cloud_mask(ncol,nlay))
+    !$acc enter        data create(   cloud_mask, lwp, iwp, rel, dei)
+    !$omp target enter data map(alloc:cloud_mask, lwp, iwp, rel, dei)
 
     ! Restrict clouds to troposphere (> 100 hPa = 100*100 Pa)
     !   and not very close to the ground (< 900 hPa), and
@@ -634,14 +634,14 @@ contains
     !   total cloudiness of earth
     if(do_rrtmgp) then
       rel_val = 0.5 * (cloud_optics%get_min_radius_liq() + cloud_optics%get_max_radius_liq())
-      rei_val = 0.5 * (cloud_optics%get_min_radius_ice() + cloud_optics%get_max_radius_ice())
+      dei_val = 0.5 * (cloud_optics%get_min_diameter_ice() + cloud_optics%get_max_diameter_ice())
     else if (do_ssm) then
       ! Arbitrary values - SSM doesn't care
       rel_val = 10._wp
-      rei_val = 20._wp
+      dei_val = 20._wp
     end if
-    !$acc                         parallel loop    collapse(2) copyin(t_lay) copyout( lwp, iwp, rel, rei)
-    !$omp target teams distribute parallel do simd collapse(2) map(to:t_lay) map(from:lwp, iwp, rel, rei)
+    !$acc                         parallel loop    collapse(2) copyin(t_lay) copyout( lwp, iwp, rel, dei)
+    !$omp target teams distribute parallel do simd collapse(2) map(to:t_lay) map(from:lwp, iwp, rel, dei)
     do ilay=1,nlay
       do icol=1,ncol
         cloud_mask(icol,ilay) = p_lay(icol,ilay) > 100._wp * 100._wp .and. &
@@ -653,7 +653,7 @@ contains
         lwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) .and. t_lay(icol,ilay) > 263._wp)
         iwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) .and. t_lay(icol,ilay) < 273._wp)
         rel(icol,ilay) = merge(rel_val, 0._wp, lwp(icol,ilay) > 0._wp)
-        rei(icol,ilay) = merge(rei_val, 0._wp, iwp(icol,ilay) > 0._wp)
+        rei(icol,ilay) = merge(dei_val, 0._wp, iwp(icol,ilay) > 0._wp)
       end do
     end do
     !$acc exit data delete(cloud_mask)
@@ -824,7 +824,7 @@ contains
       call create_var("lwp", ncid, [col_dim, lay_dim])
       call create_var("iwp", ncid, [col_dim, lay_dim])
       call create_var("rel", ncid, [col_dim, lay_dim])
-      call create_var("rei", ncid, [col_dim, lay_dim])
+      call create_var("dei", ncid, [col_dim, lay_dim])
     end if
     if(do_aerosols) then
       if(nf90_def_var(ncid, "aero_type", NF90_SHORT, [col_dim, lay_dim], varid) /= NF90_NOERR) &
@@ -863,12 +863,12 @@ contains
     call stop_on_err(write_field(ncid, "o3",     vmr))
 
     if(do_clouds) then
-      !$acc        update host(lwp, iwp, rel, rei)
-      !$omp target update from(lwp, iwp, rel, rei)
+      !$acc        update host(lwp, iwp, rel, dei)
+      !$omp target update from(lwp, iwp, rel, dei)
       call stop_on_err(write_field(ncid, "lwp",  lwp))
       call stop_on_err(write_field(ncid, "iwp",  iwp))
       call stop_on_err(write_field(ncid, "rel",  rel))
-      call stop_on_err(write_field(ncid, "rei",  rei))
+      call stop_on_err(write_field(ncid, "dei",  dei))
     end if
 
     if(do_aerosols) then

--- a/rrtmgp/frontend/mo_cloud_optics_rrtmgp.F90
+++ b/rrtmgp/frontend/mo_cloud_optics_rrtmgp.F90
@@ -209,14 +209,14 @@ contains
   ! Compute single-scattering properties
   !
   function cloud_optics(this,                     &
-                        clwp, ciwp, reliq, reice, &
+                        clwp, ciwp, reliq, diamice, &
                         optical_props) result(error_msg)
     class(ty_cloud_optics_rrtmgp), &
               intent(in   ) :: this
     real(wp), intent(in   ) :: clwp  (:,:), &   ! cloud liquid water path (g/m2)
                                ciwp  (:,:), &   ! cloud ice water path    (g/m2)
                                reliq (:,:), &   ! cloud liquid particle effective size (microns)
-                               reice (:,:)      ! cloud ice particle effective radius  (microns)
+                               diamice (:,:)    ! cloud ice particle effective diameter  (microns)
     class(ty_optical_props_arry), &
               intent(inout) :: optical_props
                                                ! Dimensions: (ncol,nlay,ngpt/nbnd)
@@ -261,8 +261,8 @@ contains
         error_msg = "cloud optics: ciwp has wrong extents"
       if(size(reliq, 1) /= ncol .or. size(reliq, 2) /= nlay) &
         error_msg = "cloud optics: reliq has wrong extents"
-      if(size(reice, 1) /= ncol .or. size(reice, 2) /= nlay) &
-        error_msg = "cloud optics: reice has wrong extents"
+      if(size(diamice, 1) /= ncol .or. size(diamice, 2) /= nlay) &
+        error_msg = "cloud optics: diamice has wrong extents"
       if(optical_props%get_ncol() /= ncol .or. optical_props%get_nlay() /= nlay) &
         error_msg = "cloud optics: optical_props have wrong extents"
       if(error_msg /= "") return
@@ -277,10 +277,10 @@ contains
       if(error_msg /= "") return
     end if
 
-    !$acc data copyin(clwp, ciwp, reliq, reice)                         &
+    !$acc data copyin(clwp, ciwp, reliq, diamice)                         &
     !$acc      create(ltau, ltaussa, ltaussag, itau, itaussa, itaussag) &
     !$acc      create(liqmsk,icemsk)
-    !$omp target data map(to:clwp, ciwp, reliq, reice) &
+    !$omp target data map(to:clwp, ciwp, reliq, diamice) &
     !$omp map(alloc:ltau, ltaussa, ltaussag, itau, itaussa, itaussag) &
     !$omp map(alloc:liqmsk, icemsk)
     !
@@ -301,8 +301,8 @@ contains
     if(check_values) then
       if(any_vals_outside(reliq, liqmsk, this%radliq_lwr, this%radliq_upr)) &
         error_msg = 'cloud optics: liquid effective radius is out of bounds'
-      if(any_vals_outside(reice, icemsk, this%diamice_lwr, this%diamice_upr)) &
-        error_msg = 'cloud optics: ice effective radius is out of bounds'
+      if(any_vals_outside(diamice, icemsk, this%diamice_lwr, this%diamice_upr)) &
+        error_msg = 'cloud optics: ice effective diameter is out of bounds'
       if(any_vals_less_than(clwp, liqmsk, 0._wp) .or. any_vals_less_than(ciwp, icemsk, 0._wp)) &
         error_msg = 'cloud optics: negative clwp or ciwp where clouds are supposed to be'
     end if
@@ -332,7 +332,7 @@ contains
         !
         ! Ice
         !
-        call compute_cld_from_table(ncol, nlay, ngpt, icemsk, ciwp, reice,              &
+        call compute_cld_from_table(ncol, nlay, ngpt, icemsk, ciwp, diamice,              &
                                     this%ice_nsteps,this%ice_step_size,this%diamice_lwr,&
                                     this%extice(:,:,this%icergh),                       &
                                     this%ssaice(:,:,this%icergh),                       &

--- a/rrtmgp/frontend/mo_cloud_optics_rrtmgp.F90
+++ b/rrtmgp/frontend/mo_cloud_optics_rrtmgp.F90
@@ -60,9 +60,9 @@ module mo_cloud_optics_rrtmgp
     procedure, public :: finalize
     procedure, public :: cloud_optics
     procedure, public :: get_min_radius_liq
-    procedure, public :: get_min_radius_ice
+    procedure, public :: get_min_diameter_ice
     procedure, public :: get_max_radius_liq
-    procedure, public :: get_max_radius_ice
+    procedure, public :: get_max_diameter_ice
     procedure, public :: get_num_ice_roughness_types
     procedure, public :: set_ice_roughness
   end type ty_cloud_optics_rrtmgp
@@ -209,14 +209,14 @@ contains
   ! Compute single-scattering properties
   !
   function cloud_optics(this,                     &
-                        clwp, ciwp, reliq, diamice, &
+                        clwp, ciwp, reliq, dgice, &
                         optical_props) result(error_msg)
     class(ty_cloud_optics_rrtmgp), &
               intent(in   ) :: this
-    real(wp), intent(in   ) :: clwp  (:,:), &   ! cloud liquid water path (g/m2)
-                               ciwp  (:,:), &   ! cloud ice water path    (g/m2)
-                               reliq (:,:), &   ! cloud liquid particle effective size (microns)
-                               diamice (:,:)    ! cloud ice particle effective diameter  (microns)
+    real(wp), intent(in   ) :: clwp  (:,:), & ! cloud liquid water path (g/m2)
+                               ciwp  (:,:), & ! cloud ice water path    (g/m2)
+                               reliq (:,:), & ! cloud liquid particle effective radius (microns)
+                               dgice (:,:)    ! cloud ice particle effective diameter (microns)
     class(ty_optical_props_arry), &
               intent(inout) :: optical_props
                                                ! Dimensions: (ncol,nlay,ngpt/nbnd)
@@ -261,8 +261,8 @@ contains
         error_msg = "cloud optics: ciwp has wrong extents"
       if(size(reliq, 1) /= ncol .or. size(reliq, 2) /= nlay) &
         error_msg = "cloud optics: reliq has wrong extents"
-      if(size(diamice, 1) /= ncol .or. size(diamice, 2) /= nlay) &
-        error_msg = "cloud optics: diamice has wrong extents"
+      if(size(dgice, 1) /= ncol .or. size(dgice, 2) /= nlay) &
+        error_msg = "cloud optics: dgice has wrong extents"
       if(optical_props%get_ncol() /= ncol .or. optical_props%get_nlay() /= nlay) &
         error_msg = "cloud optics: optical_props have wrong extents"
       if(error_msg /= "") return
@@ -277,10 +277,10 @@ contains
       if(error_msg /= "") return
     end if
 
-    !$acc data copyin(clwp, ciwp, reliq, diamice)                         &
+    !$acc data copyin(clwp, ciwp, reliq, dgice)                         &
     !$acc      create(ltau, ltaussa, ltaussag, itau, itaussa, itaussag) &
     !$acc      create(liqmsk,icemsk)
-    !$omp target data map(to:clwp, ciwp, reliq, diamice) &
+    !$omp target data map(to:clwp, ciwp, reliq, dgice) &
     !$omp map(alloc:ltau, ltaussa, ltaussag, itau, itaussa, itaussag) &
     !$omp map(alloc:liqmsk, icemsk)
     !
@@ -301,7 +301,7 @@ contains
     if(check_values) then
       if(any_vals_outside(reliq, liqmsk, this%radliq_lwr, this%radliq_upr)) &
         error_msg = 'cloud optics: liquid effective radius is out of bounds'
-      if(any_vals_outside(diamice, icemsk, this%diamice_lwr, this%diamice_upr)) &
+      if(any_vals_outside(dgice, icemsk, this%diamice_lwr, this%diamice_upr)) &
         error_msg = 'cloud optics: ice effective diameter is out of bounds'
       if(any_vals_less_than(clwp, liqmsk, 0._wp) .or. any_vals_less_than(ciwp, icemsk, 0._wp)) &
         error_msg = 'cloud optics: negative clwp or ciwp where clouds are supposed to be'
@@ -332,7 +332,7 @@ contains
         !
         ! Ice
         !
-        call compute_cld_from_table(ncol, nlay, ngpt, icemsk, ciwp, diamice,              &
+        call compute_cld_from_table(ncol, nlay, ngpt, icemsk, ciwp, dgice,              &
                                     this%ice_nsteps,this%ice_step_size,this%diamice_lwr,&
                                     this%extice(:,:,this%icergh),                       &
                                     this%ssaice(:,:,this%icergh),                       &
@@ -426,17 +426,17 @@ contains
     r = this%radliq_upr
   end function get_max_radius_liq
   !-----------------------------------------------
-  function get_min_radius_ice(this) result(r)
+  function get_min_diameter_ice(this) result(d)
     class(ty_cloud_optics_rrtmgp), intent(in   ) :: this
-    real(wp)                              :: r
+    real(wp)                              :: d
 
-    r = this%diamice_lwr
-  end function get_min_radius_ice
+    d = this%diamice_lwr
+  end function get_min_diameter_ice
   !-----------------------------------------------
-  function get_max_radius_ice(this) result(r)
+  function get_max_diameter_ice(this) result(d)
     class(ty_cloud_optics_rrtmgp), intent(in   ) :: this
-    real(wp)                              :: r
+    real(wp)                              :: d
 
-    r = this%diamice_upr
-  end function get_max_radius_ice
+    d = this%diamice_upr
+  end function get_max_diameter_ice
 end module mo_cloud_optics_rrtmgp

--- a/ssm/mo_optics_ssm.F90
+++ b/ssm/mo_optics_ssm.F90
@@ -537,14 +537,14 @@ contains
   !> Derive cloud optical properties from provided cloud physical properties
   !
   function cloud_optics(this,                     &
-                        clwp, ciwp, reliq, reice, &
+                        clwp, ciwp, reliq, deice, &
                         optical_props) result(error_msg)
     class(ty_optics_ssm), &
               intent(in   ) :: this
     real(wp), intent(in   ) :: clwp  (:,:), &   ! cloud liquid water path (g/m2)
                                ciwp  (:,:), &   ! cloud ice water path    (g/m2)
                                reliq (:,:), &   ! cloud liquid particle effective size (microns)
-                               reice (:,:)      ! cloud ice particle effective radius  (microns)
+                               deice (:,:)      ! cloud ice particle effective diameter (microns)
     class(ty_optical_props_arry), &
               intent(inout) :: optical_props
     character(len=128)      :: error_msg


### PR DESCRIPTION
In mo_cloud_optics_rrtmgp, reice has been renamed to diamice, since for ice, the effective diameter is used. Furthermore, one comment and one write statement have also been updated accordingly.

This refers to #399 .

For now, I did not change the names of the functions get_min_radius_ice and get_max_radius_ice, since this might break users' couplers. Do you want me to rename them as well?