### PR TITLE
Various fixes and workaround for amdflang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU AND NOT RTE_RRTMGP_Fortran_is_NEC)
 endif()
 
 if(${CMAKE_Fortran_COMPILER_ID} MATCHES LLVMFlang)
+  # replace parameter local array in kernel by module global array use explicit
+  # openmp target loops
   add_compile_definitions(AMDFLANG_WORKAROUND)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU AND NOT RTE_RRTMGP_Fortran_is_NEC)
   add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>)
 endif()
 
+if(${CMAKE_Fortran_COMPILER_ID} MATCHES LLVMFlang)
+  add_compile_definitions(AMDFLANG_WORKAROUND)
+endif()
+
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules)
 
 if(RTE_BUILD_TESTING OR RTE_BUILD_C_HEADERS)

--- a/rrtmgp/frontend/mo_aerosol_optics_rrtmgp_merra.F90
+++ b/rrtmgp/frontend/mo_aerosol_optics_rrtmgp_merra.F90
@@ -581,14 +581,25 @@ contains
     integer, dimension(:,:), intent(in) :: array
     integer,                 intent(in) :: checkMin, checkMax
 
-    integer :: minValue, maxValue
+    integer :: minValue, maxValue, i, j
 
+#ifndef AMDFLANG_WORKAROUND
     !$acc kernels copyin(array)
     !$omp target map(to:array) map(from:minValue, maxValue)
     minValue = minval(array)
     maxValue = maxval(array)
     !$acc end kernels
     !$omp end target
+#else
+    !$omp target teams distribute parallel do collapse(2) &
+    !$omp& reduction(min:minValue) reduction(max:maxValue) map(to:array)
+    do j = 1, size(array, 2)
+       do i = 1, size(array, 1)
+          minValue = min(array(i,j), minValue)
+          maxValue = max(array(i,j), maxValue)
+       end do
+    end do
+#endif
     any_int_vals_outside_2D = minValue < checkMin .or. maxValue > checkMax
 
   end function any_int_vals_outside_2D

--- a/rrtmgp/frontend/mo_cloud_optics_rrtmgp.F90
+++ b/rrtmgp/frontend/mo_cloud_optics_rrtmgp.F90
@@ -99,7 +99,7 @@ contains
     ! Local variables
     !
     integer :: nrghice, nsize_liq, nsize_ice
-    integer :: ngpt
+    integer :: ngpt,i,j,k
 
     error_msg = this%init(band_lims_wvn, band_lims_gpt, name="RRTMGP cloud optics")
     !
@@ -152,6 +152,7 @@ contains
     this%diamice_upr = diamice_upr
 
     ! Load LUT coefficients
+#ifndef AMDFLANG_WORKAROUND
     !$acc kernels
     !$omp target
     this%extliq = extliq
@@ -162,6 +163,50 @@ contains
     this%asyice = asyice
     !$acc end kernels
     !$omp end target
+#else
+    !$omp target teams distribute parallel do collapse(2)
+    do j = 1, size(extliq, 2)
+       do i = 1, size(extliq, 1)
+          this%extliq(i,j) = extliq(i,j)
+       end do
+    end do
+    !$omp target teams distribute parallel do collapse(2)
+    do j = 1, size(ssaliq, 2)
+       do i = 1, size(ssaliq, 1)
+          this%ssaliq(i,j) = ssaliq(i,j)
+       end do
+    end do
+    !$omp target teams distribute parallel do collapse(2)
+    do j = 1, size(asyliq, 2)
+       do i = 1, size(asyliq, 1)
+          this%asyliq(i,j) = asyliq(i,j)
+       end do
+    end do
+    !$omp target teams distribute parallel do collapse(3)
+    do k = 1, size(extice, 3)
+       do j = 1, size(extice, 2)
+          do i = 1, size(extice, 1)
+             this%extice(i,j,k) = extice(i,j,k)
+          end do
+       end do
+    end do
+    !$omp target teams distribute parallel do collapse(3)
+    do k = 1, size(ssaice, 3)
+       do j = 1, size(ssaice, 2)
+          do i = 1, size(ssaice, 1)
+             this%ssaice(i,j,k) = ssaice(i,j,k)
+          end do
+       end do
+    end do
+    !$omp target teams distribute parallel do collapse(3)
+    do k = 1, size(asyice, 3)
+       do j = 1, size(asyice, 2)
+          do i = 1, size(asyice, 1)
+             this%asyice(i,j,k) = asyice(i,j,k)
+          end do
+       end do
+    end do
+#endif
     !
     ! Set default ice roughness - min values
     !

--- a/rrtmgp/frontend/mo_gas_optics_rrtmgp.F90
+++ b/rrtmgp/frontend/mo_gas_optics_rrtmgp.F90
@@ -1091,7 +1091,7 @@ contains
                                  allocatable :: rayl_lower, rayl_upper
     character(len = 128) err_message
 
-    integer :: ngpt
+    integer :: ngpt,igpt
     ! ----
     !$acc enter data copyin(this)
     call this%finalize()
@@ -1124,6 +1124,7 @@ contains
                this%solar_source_sunspot(ngpt), this%solar_source(ngpt))
       !$acc        enter data create(   this%solar_source_quiet, this%solar_source_facular, this%solar_source_sunspot, this%solar_source)
       !$omp target enter data map(alloc:this%solar_source_quiet, this%solar_source_facular, this%solar_source_sunspot, this%solar_source)
+#ifndef AMDFLANG_WORKAROUND
       !$acc kernels
       !$omp target
       this%solar_source_quiet   = solar_quiet
@@ -1131,6 +1132,14 @@ contains
       this%solar_source_sunspot = solar_sunspot
       !$acc end kernels
       !$omp end target
+#else
+      !$omp target teams distribute parallel do
+      do igpt = 1, ngpt
+         this%solar_source_quiet(igpt)   = solar_quiet(igpt)
+         this%solar_source_facular(igpt) = solar_facular(igpt)
+         this%solar_source_sunspot(igpt) = solar_sunspot(igpt)
+      end do
+#endif
       err_message = this%set_solar_variability(mg_default, sb_default)
     endif
   end function load_ext

--- a/rte/frontend/gas-optics-template/mo_gas_concentrations.F90
+++ b/rte/frontend/gas-optics-template/mo_gas_concentrations.F90
@@ -134,7 +134,7 @@ contains
     character(len=128)                 :: error_msg !! error string, empty when successful
     ! ---------
     real(wp), dimension(:,:), pointer :: p
-    integer :: igas
+    integer :: igas,i,j
     ! ---------
     error_msg = ''
     if (w < 0._wp .or. w > 1._wp) then
@@ -167,14 +167,27 @@ contains
 
     p => this%concs(igas)%conc(:,:)
     !$acc kernels
+#ifndef AMDFLANG_WORKAROUND
     !$omp target map(to:w)
+#endif
 #ifdef _CRAYFTN
     p(:,:) = w
 #else
-    this%concs(igas)%conc(:,:) = w
+#ifndef AMDFLANG_WORKAROUND
+    this%concs(igas)%conc(1,:) = w
+#else
+    !$omp target teams distribute parallel do collapse(2) map(to:w)
+    do j = 1, size(this%concs(igas)%conc, 2)
+       do i = 1, size(this%concs(igas)%conc, 1)
+          this%concs(igas)%conc(i,j) = w
+       end do
+    end do
+#endif
 #endif
     !$acc end kernels
+#ifndef AMDFLANG_WORKAROUND
     !$omp end target
+#endif
   end function set_vmr_scalar
   ! -------------------------------------------------------------------------------------
   !> ### Set 1d (function of level) concentrations
@@ -187,7 +200,7 @@ contains
     character(len=128)                 :: error_msg !! error string, empty when successful
     ! ---------
     real(wp), dimension(:,:), pointer :: p
-    integer :: igas
+    integer :: igas,i
     ! ---------
     error_msg = ''
 
@@ -227,14 +240,25 @@ contains
 
     p => this%concs(igas)%conc(:,:)
     !$acc kernels copyin(w)
+#ifndef AMDFLANG_WORKAROUND
     !$omp target map(to:w)
+#endif
 #ifdef _CRAYFTN
     p(1,:) = w
 #else
+#ifndef AMDFLANG_WORKAROUND
     this%concs(igas)%conc(1,:) = w
+#else
+    !$omp target teams distribute parallel do map(to:w)
+    do i = 1, size(this%concs(igas)%conc, 2)
+       this%concs(igas)%conc(1,i) = w(i)
+    end do
+#endif
 #endif
     !$acc end kernels
+#ifndef AMDFLANG_WORKAROUND
     !$omp end target
+#endif
 
     !$acc exit data delete(w)
   end function set_vmr_1d
@@ -250,7 +274,7 @@ contains
                                               !! error string, empty when successful
     ! ---------
     real(wp), dimension(:,:), pointer :: p
-    integer :: igas
+    integer :: igas,i,j
     ! ---------
     error_msg = ''
 
@@ -297,14 +321,27 @@ contains
 
     p => this%concs(igas)%conc(:,:)
     !$acc kernels copyin(w)
+#ifndef AMDFLANG_WORKAROUND
     !$omp target map(to:w)
+#endif
 #ifdef _CRAYFTN
     p(:,:) = w(:,:)
 #else
+#ifndef AMDFLANG_WORKAROUND
     this%concs(igas)%conc(:,:) = w(:,:)
+#else
+    !$omp target teams distribute parallel do collapse(2) map(to:w)
+    do j = 1, size(this%concs(igas)%conc, 2)
+       do i = 1, size(this%concs(igas)%conc, 1)
+          this%concs(igas)%conc(i,j) = w(i,j)
+       end do
+    end do
+#endif
 #endif
     !$acc end kernels
+#ifndef AMDFLANG_WORKAROUND
     !$omp end target
+#endif
   end function set_vmr_2d
   ! -------------------------------------------------------------------------------------
   !
@@ -321,7 +358,7 @@ contains
     character(len=128) :: error_msg                !! Error string, empty if successful
     ! ---------------------
     real(wp), dimension(:,:), pointer :: p
-    integer :: igas
+    integer :: igas,i
     ! ---------------------
     error_msg = ''
 
@@ -344,24 +381,46 @@ contains
     !$omp target data map(from:array)
     if(size(this%concs(igas)%conc, 2) > 1) then
       !$acc kernels present(p)
+#ifndef AMDFLANG_WORKAROUND
       !$omp target
+#endif
 #ifdef _CRAYFTN
       array(:) = p(1,:)
 #else
+#ifndef AMDFLANG_WORKAROUND
       array(:) = this%concs(igas)%conc(1,:)
+#else
+      !$omp target teams distribute parallel do
+      do i = 1, size(array, 1)
+         array(i) = this%concs(igas)%conc(1,i)
+      end do
+#endif
 #endif
       !$acc end kernels
+#ifndef AMDFLANG_WORKAROUND
       !$omp end target
+#endif
     else
       !$acc kernels present(p)
+#ifndef AMDFLANG_WORKAROUND
       !$omp target
+#endif
 #ifdef _CRAYFTN
       array(:) = p(1,1)
 #else
+#ifndef AMDFLANG_WORKAROUND
       array(:) = this%concs(igas)%conc(1,1)
+#else
+      !$omp target teams distribute parallel do
+      do i = 1, size(array, 1)
+         array(i) = this%concs(igas)%conc(1,1)
+      end do
+#endif
 #endif
       !$acc end kernels
+#ifndef AMDFLANG_WORKAROUND
       !$omp end target
+#endif
     end if
     !$acc end data
     !$omp end target data
@@ -455,7 +514,7 @@ contains
     character(len=128)                      :: error_msg !! Error string, empty if successful
     ! ---------------------
     real(wp), dimension(:,:), pointer :: p1, p2
-    integer :: i
+    integer :: i,j,k
     ! ---------------------
     error_msg = ''
     if(n <= 0) &
@@ -488,24 +547,50 @@ contains
       !$omp target enter data map(alloc:subset%concs(i)%conc)
       if(size(this%concs(i)%conc, 1) > 1) then      ! Concentration stored as 2D
         !$acc kernels
+#ifndef AMDFLANG_WORKAROUND
         !$omp target
+#endif
 #ifdef _CRAYFTN
         p1(:,:) = p2(start:(start+n-1),:)
 #else
+#ifndef AMDFLANG_WORKAROUND
         subset%concs(i)%conc(:,:) = this%concs(i)%conc(start:(start+n-1),:)
+#else
+        !$omp target teams distribute parallel do collapse(2)
+        do k = 1, size(subset%concs(i)%conc, 2)
+           do j = 1, size(subset%concs(i)%conc, 1)
+              subset%concs(i)%conc(j,k) = this%concs(i)%conc(start+j-1, k)
+           end do
+        end do
+#endif
 #endif
         !$acc end kernels
+#ifndef AMDFLANG_WORKAROUND
         !$omp end target
+#endif
       else
         !$acc kernels
+#ifndef AMDFLANG_WORKAROUND
         !$omp target
+#endif
 #ifdef _CRAYFTN
         p1(:,:) = p2(:,:)
 #else
+#ifndef AMDFLANG_WORKAROUND
         subset%concs(i)%conc(:,:) = this%concs(i)%conc(:,:)
+#else
+        !$omp target teams distribute parallel do collapse(2)
+        do k = 1, size(subset%concs(i)%conc, 2)
+           do j = 1, size(subset%concs(i)%conc, 1)
+              subset%concs(i)%conc(j,k) = this%concs(i)%conc(j, k)
+           end do
+        end do
+#endif
 #endif
         !$acc end kernels
+#ifndef AMDFLANG_WORKAROUND
         !$omp end target
+#endif
       end if
     end do
 

--- a/rte/frontend/mo_rte_lw.F90
+++ b/rte/frontend/mo_rte_lw.F90
@@ -62,11 +62,11 @@ module mo_rte_lw
 
   public :: rte_lw
 
-#undef STATIC
-#ifndef STATIC
+#ifdef AMDFLANG_WORKAROUND
   integer, parameter :: max_gauss_pts = 4
   real(wp), dimension(max_gauss_pts, max_gauss_pts) :: gauss_Ds, gauss_wts
   !$omp declare target(gauss_Ds, gauss_wts)
+  !$acc declare create(gauss_Ds, gauss_wts)
 #endif
 
 contains
@@ -135,7 +135,7 @@ contains
     ! Weights and angle secants for "Gauss-Jacobi-5" quadrature.
     !   Values from Table 1, R. J. Hogan 2023, doi:10.1002/qj.4598
     !
-#ifdef STATIC
+#ifndef AMDFLANG_WORKAROUND
     integer,  parameter :: max_gauss_pts = 4
     real(wp), parameter,                         &
       dimension(max_gauss_pts, max_gauss_pts) :: &
@@ -149,7 +149,7 @@ contains
                              1._wp/0.0454586727_wp, 1._wp/0.2322334416_wp,  &
                              1._wp/0.5740198775_wp, 1._wp/0.9030775973_wp], &
                             [max_gauss_pts, max_gauss_pts])
-#ifdef STATIC
+#ifndef AMDFLANG_WORKAROUND
     real(wp), parameter,                         &
       dimension(max_gauss_pts, max_gauss_pts) :: &
 #endif

--- a/rte/frontend/mo_rte_lw.F90
+++ b/rte/frontend/mo_rte_lw.F90
@@ -61,7 +61,16 @@ module mo_rte_lw
   private
 
   public :: rte_lw
+
+#undef STATIC
+#ifndef STATIC
+  integer, parameter :: max_gauss_pts = 4
+  real(wp), dimension(max_gauss_pts, max_gauss_pts) :: gauss_Ds, gauss_wts
+  !$omp declare target(gauss_Ds, gauss_wts)
+#endif
+
 contains
+
   ! --------------------------------------------------
   !
   ! Interface using only optical properties and source functions as inputs; fluxes as outputs.
@@ -126,9 +135,11 @@ contains
     ! Weights and angle secants for "Gauss-Jacobi-5" quadrature.
     !   Values from Table 1, R. J. Hogan 2023, doi:10.1002/qj.4598
     !
+#ifdef STATIC
     integer,  parameter :: max_gauss_pts = 4
     real(wp), parameter,                         &
       dimension(max_gauss_pts, max_gauss_pts) :: &
+#endif
         !
         ! Values provided are for mu = cos(theta); we require the inverse
         !
@@ -137,7 +148,11 @@ contains
                              1._wp/0.1024922169_wp, 1._wp/0.4417960320_wp, 1._wp/0.8633751621_wp, 0._wp, &
                              1._wp/0.0454586727_wp, 1._wp/0.2322334416_wp,  &
                              1._wp/0.5740198775_wp, 1._wp/0.9030775973_wp], &
-                            [max_gauss_pts, max_gauss_pts]),              &
+                            [max_gauss_pts, max_gauss_pts])
+#ifdef STATIC
+    real(wp), parameter,                         &
+      dimension(max_gauss_pts, max_gauss_pts) :: &
+#endif
         gauss_wts = RESHAPE([1._wp,           0._wp,           0._wp,           0._wp, &
                              0.2300253764_wp, 0.7699746236_wp, 0._wp,           0._wp, &
                              0.0437820218_wp, 0.3875796738_wp, 0.5686383044_wp, 0._wp, &

--- a/rte/frontend/mo_rte_sw.F90
+++ b/rte/frontend/mo_rte_sw.F90
@@ -126,6 +126,7 @@ contains
     !
     integer     :: ncol, nlay, ngpt, nband
     integer     :: icol, ilev
+    integer     :: i,j,k
     logical(wl) :: has_dif_bc, do_broadband
 
     real(wp), dimension(:,:,:), pointer             :: gpt_flux_up, gpt_flux_dn, gpt_flux_dir
@@ -294,11 +295,22 @@ contains
                                 gpt_flux_dir)
           call zero_array(ncol, nlay+1, ngpt, gpt_flux_up)
           !
+#ifndef AMDFLANG_WORKAROUND
           !$acc kernels
           !$omp target
           gpt_flux_dn(:,:,:) = gpt_flux_dir(:,:,:)
           !$acc end kernels
           !$omp end target
+#else
+          !$omp target teams distribute parallel do collapse(3)
+          do k = 1, size(gpt_flux_dn, 3)
+             do j = 1, size(gpt_flux_dn, 2)
+                do i = 1, size(gpt_flux_dn, 1)
+                   gpt_flux_dn(i,j,k) = gpt_flux_dir(i,j,k)
+                end do
+             end do
+          end do
+#endif
 
         class is (ty_optical_props_2str)
           !


### PR DESCRIPTION
Some fixes to be able to compile with latest AMD's flang with OpenMP offload
- using parameter arrays in kernel seems unsupported, use global module variable instead
- some array assignment statement in **serial** `omp target` directives would cause compiler link errors
  + fixed in ROCm 7.13 beta
  + replaced by explicit parallel loops, as `workdistribute` isn't supported yet