### PR TITLE
Add CTest configuration for rte_examples

### DIFF
--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -15,6 +15,54 @@ target_link_libraries(rte_examples_io PRIVATE shared-utils)
 
 # ##############################################################################
 #
+# Fetch the rte-examples atmospheric state data
+#
+if(RTE_EXAMPLES_DATA)
+  add_test(NAME fetch_rte_examples_data COMMAND ${CMAKE_COMMAND} -E true)
+  message(
+    NOTICE
+    "Using an external dataset from ${RTE_EXAMPLES_DATA}: the data files will not be installed"
+  )
+else()
+  set(RTE_EXAMPLES_DATA "${PROJECT_BINARY_DIR}/rte-examples-data")
+
+  include(ExternalProject)
+  ExternalProject_Add(
+    rte-examples-data
+    GIT_REPOSITORY git@github.com:earth-system-radiation/rte-examples.git
+    GIT_TAG "main"
+    GIT_SHALLOW True
+    EXCLUDE_FROM_ALL True
+    PREFIX rte-examples-data-cmake
+    SOURCE_DIR ${RTE_EXAMPLES_DATA}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+  )
+
+  set(fetch_rte_examples_data_command
+    ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config
+      "$<CONFIG>" --target rte-examples-data
+  )
+
+  add_test(NAME fetch_rte_examples_data COMMAND ${fetch_rte_examples_data_command})
+
+  install(CODE "execute_process(COMMAND ${fetch_rte_examples_data_command})")
+  install(
+    FILES # cmake-format: sort
+          ${RTE_EXAMPLES_DATA}/rfmip-states.nc
+          ${RTE_EXAMPLES_DATA}/ckdmip-states.nc
+          ${RTE_EXAMPLES_DATA}/rce-states.nc
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
+  )
+endif()
+
+set_tests_properties(
+  fetch_rte_examples_data PROPERTIES FIXTURES_SETUP fetch_rte_examples_data
+)
+
+# ##############################################################################
+#
 # RTE tests using homogenized examples
 #
 # Build the two executables
@@ -34,3 +82,37 @@ target_link_libraries(
           rte-rrtmgp::rrtmgp
           rte-rrtmgp::ssm
 )
+
+# ##############################################################################
+#
+# RTE tests: 2 schemes x 2 bands x 3 states = 12 tests
+#
+foreach(scheme IN ITEMS rrtmgp ssm)
+  foreach(band IN ITEMS lw sw)
+    # scheme_data depends on scheme and band
+    if(scheme STREQUAL "rrtmgp")
+      if(band STREQUAL "lw")
+        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc)
+      else()
+        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc)
+      endif()
+    else() # ssm
+      set(scheme_data ${band})
+    endif()
+
+    foreach(state IN ITEMS rfmip ckdmip rce)
+      add_test(
+        NAME run_rte_examples_${scheme}_${band}_${state}
+        COMMAND
+          rte_examples 8 ${scheme} ${scheme_data}
+          ${RTE_EXAMPLES_DATA}/${state}-states.nc
+          ${CMAKE_CURRENT_BINARY_DIR}/${scheme}_${band}_${state}.nc
+      )
+      set_tests_properties(
+        run_rte_examples_${scheme}_${band}_${state}
+        PROPERTIES FIXTURES_REQUIRED
+                   "fetch_rrtmgp_data;fetch_rte_examples_data"
+      )
+    endforeach()
+  endforeach()
+endforeach()

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -41,18 +41,20 @@ else()
   )
 
   set(fetch_rte_examples_data_command
-    ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config
-      "$<CONFIG>" --target rte-examples-data
+      ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config "$<CONFIG>"
+      --target rte-examples-data
   )
 
-  add_test(NAME fetch_rte_examples_data COMMAND ${fetch_rte_examples_data_command})
+  add_test(
+    NAME fetch_rte_examples_data COMMAND ${fetch_rte_examples_data_command}
+  )
 
   install(CODE "execute_process(COMMAND ${fetch_rte_examples_data_command})")
   install(
     FILES # cmake-format: sort
-          ${RTE_EXAMPLES_DATA}/rfmip-states.nc
           ${RTE_EXAMPLES_DATA}/ckdmip-states.nc
           ${RTE_EXAMPLES_DATA}/rce-states.nc
+          ${RTE_EXAMPLES_DATA}/rfmip-states.nc
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
   )
 endif()

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -29,8 +29,8 @@ else()
   include(ExternalProject)
   ExternalProject_Add(
     rte-examples-data
-    GIT_REPOSITORY git@github.com:earth-system-radiation/rte-examples.git
-    GIT_TAG "main"
+    GIT_REPOSITORY https://github.com/earth-system-radiation/rte-examples.git
+    GIT_TAG "v0.1.1"
     GIT_SHALLOW True
     EXCLUDE_FROM_ALL True
     PREFIX rte-examples-data-cmake


### PR DESCRIPTION
Adds CMake/CTest support for the rte_examples executable in examples/rte-examples/. The atmospheric state data (RFMIP, CKDMIP, RCE) is fetched from the rte-examples repository as a CTest fixture using the same ExternalProject pattern used for rrtmgp-data. An alternative path can be supplied via the RTE_EXAMPLES_DATA cache variable to skip the fetch.

Twelve tests are registered covering all combinations of optics scheme (RRTMGP, SSM), spectral band (LW, SW), and atmospheric state (RFMIP, CKDMIP, RCE). All tests depend on the fetch_rrtmgp_data and fetch_rte_examples_data fixtures, ensuring data is in place before any run is attempted.