### PR TITLE
Fix ifx compatibility: slice varnames to avoid blank entries in pack

### DIFF
--- a/examples/rte-examples/mo_rte_examples_io.F90
+++ b/examples/rte-examples/mo_rte_examples_io.F90
@@ -69,8 +69,15 @@ contains
                         .and. (xtype == NF90_FLOAT .or. xtype == NF90_DOUBLE))
       end if
     end do
+    ! write out varnames and is_gas for debugging
+    ngases = 0
+    do ivar = 1, max_vars
+      if (trim(varnames(ivar)) == "") exit
+      ngases = ngases + 1
+    end do
+
     is_gas(ivar:max_vars) = .false.
-    call stop_on_err(available_gases%init(gas_names=pack(varnames, mask=is_gas(1:ivar))))
+    call stop_on_err(available_gases%init(gas_names=pack(varnames(1:ngases), mask=is_gas(1:ivar))))
 
     !
     ! The problem sizes as the calling routines will see them


### PR DESCRIPTION
When compiled with ifx, pack(varnames, mask=is_gas(1:ivar)) over the full max_vars-sized array passes uninitialized blank entries to available_gases%init(), which then (correctly) rejects them as duplicate empty gas names. Other compilers happen not to trigger this because their uninitialized slots don't survive the mask check.

Fix: count the actual variables found in the NetCDF file (ngases) and slice varnames(1:ngases) before calling pack.