### PR TITLE
Add rte-examples to CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,12 @@ if(RTE_BUILD_TESTING OR RTE_BUILD_C_HEADERS)
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
 endif()
 
+include(CTest)
+
 add_subdirectory(rte)
 add_subdirectory(rrtmgp)
 add_subdirectory(ssm)
 
-include(CTest)
 if(RTE_BUILD_TESTING)
   if(NOT _RTE_RRTMGP_HAVE_PY_PACKAGES)
     include(CheckPython3Package)

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -134,7 +134,7 @@ foreach(scheme IN ITEMS rrtmgp ssm)
       set_tests_properties(
         run_rte_examples_${scheme}_${band}_${state}
         PROPERTIES FIXTURES_REQUIRED
-                   run_rte_examples_${scheme}_${band}_${state}
+                   "fetch_ssm_data;run_rte_examples_${scheme}_${band}_${state}"
       )
     endforeach()
   endforeach()

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -94,27 +94,45 @@ foreach(scheme IN ITEMS rrtmgp ssm)
     # scheme_data depends on scheme and band
     if(scheme STREQUAL "rrtmgp")
       if(band STREQUAL "lw")
-        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc)
+        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc)
       else()
-        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc)
+        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc)
       endif()
     else() # ssm
       set(scheme_data ${band})
     endif()
 
     foreach(state IN ITEMS rfmip ckdmip rce)
+      set(output_data ${CMAKE_CURRENT_BINARY_DIR}/${scheme}-${band}-${state}.nc)
       add_test(
         NAME run_rte_examples_${scheme}_${band}_${state}
         COMMAND
           rte_examples 8 ${scheme} ${scheme_data}
-          ${RTE_EXAMPLES_DATA}/${state}-states.nc
-          ${CMAKE_CURRENT_BINARY_DIR}/${scheme}_${band}_${state}.nc
+          ${RTE_EXAMPLES_DATA}/${state}-states.nc ${output_data}
       )
       set_tests_properties(
         run_rte_examples_${scheme}_${band}_${state}
         PROPERTIES FIXTURES_REQUIRED
                    "fetch_rrtmgp_data;fetch_rte_examples_data"
       )
+
+      if(scheme STREQUAL "rrtmgp")
+        add_test(
+          NAME check_rte_examples_${scheme}_${band}_${state}
+          COMMAND
+            ${Python3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/examples/compare-to-reference.py --ref_dir
+            ${RRTMGP_DATA}/examples/rte-examples/reference --tst_dir
+            ${CMAKE_CURRENT_BINARY_DIR} --file_names ${output_data}
+            --failure_threshold ${FAILURE_THRESHOLD}
+        )
+        set_tests_properties(
+          run_rte_examples_${scheme}_${band}_${state}
+          PROPERTIES
+            FIXTURES_REQUIRED
+            "fetch_rrtmgp_data;fetch_rte_examples_data;run_rte_examples_${scheme}_${band}_${state}"
+        )
+      endif()
     endforeach()
   endforeach()
 endforeach()

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -120,6 +120,8 @@ foreach(scheme IN ITEMS rrtmgp ssm)
         run_rte_examples_${scheme}_${band}_${state}
         PROPERTIES FIXTURES_REQUIRED
                    "fetch_rrtmgp_data;fetch_rte_examples_data"
+                   FIXTURES_SETUP
+                   "run_rte_examples_${scheme}_${band}_${state}"
       )
 
       add_test(

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -134,7 +134,7 @@ foreach(scheme IN ITEMS rrtmgp ssm)
           --failure_threshold ${FAILURE_THRESHOLD}
       )
       set_tests_properties(
-        run_rte_examples_${scheme}_${band}_${state}
+        check_rte_examples_${scheme}_${band}_${state}
         PROPERTIES FIXTURES_REQUIRED
                    "fetch_ssm_data;run_rte_examples_${scheme}_${band}_${state}"
       )

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -90,13 +90,19 @@ target_link_libraries(
 # RTE tests: 2 schemes x 2 bands x 3 states = 12 tests
 #
 foreach(scheme IN ITEMS rrtmgp ssm)
+  if(scheme STREQUAL "rrtmgp")
+    set(data_dir ${RRTMGP_DATA})
+  else() # ssm
+    set(data_dir ${SSM_DATA})
+  endif()
+
   foreach(band IN ITEMS lw sw)
     # scheme_data depends on scheme and band
     if(scheme STREQUAL "rrtmgp")
       if(band STREQUAL "lw")
-        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc)
+        set(scheme_data ${data_dir}/rrtmgp-gas-lw-g128.nc)
       else()
-        set(scheme_data ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc)
+        set(scheme_data ${data_dir}/rrtmgp-gas-sw-g112.nc)
       endif()
     else() # ssm
       set(scheme_data ${band})
@@ -116,23 +122,20 @@ foreach(scheme IN ITEMS rrtmgp ssm)
                    "fetch_rrtmgp_data;fetch_rte_examples_data"
       )
 
-      if(scheme STREQUAL "rrtmgp")
-        add_test(
-          NAME check_rte_examples_${scheme}_${band}_${state}
-          COMMAND
-            ${Python3_EXECUTABLE}
-            ${CMAKE_SOURCE_DIR}/examples/compare-to-reference.py --ref_dir
-            ${RRTMGP_DATA}/examples/rte-examples/reference --tst_dir
-            ${CMAKE_CURRENT_BINARY_DIR} --file_names ${output_data}
-            --failure_threshold ${FAILURE_THRESHOLD}
-        )
-        set_tests_properties(
-          run_rte_examples_${scheme}_${band}_${state}
-          PROPERTIES
-            FIXTURES_REQUIRED
-            "fetch_rrtmgp_data;fetch_rte_examples_data;run_rte_examples_${scheme}_${band}_${state}"
-        )
-      endif()
+      add_test(
+        NAME check_rte_examples_${scheme}_${band}_${state}
+        COMMAND
+          ${Python3_EXECUTABLE}
+          ${CMAKE_SOURCE_DIR}/examples/compare-to-reference.py --ref_dir
+          ${data_dir}/examples/rte-examples/reference --tst_dir
+          ${CMAKE_CURRENT_BINARY_DIR} --file_names ${output_data}
+          --failure_threshold ${FAILURE_THRESHOLD}
+      )
+      set_tests_properties(
+        run_rte_examples_${scheme}_${band}_${state}
+        PROPERTIES FIXTURES_REQUIRED
+                   run_rte_examples_${scheme}_${band}_${state}
+      )
     endforeach()
   endforeach()
 endforeach()

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -25,3 +25,50 @@ set_target_properties(
 )
 
 install(TARGETS ssm EXPORT rte-rrtmgp-targets)
+
+# ##############################################################################
+#
+# Fetch the rte-examples atmospheric state data
+#
+if(SSM_DATA)
+  add_test(NAME fetch_ssm_data COMMAND ${CMAKE_COMMAND} -E true)
+  message(
+    NOTICE
+    "Using an external dataset from ${SSM_DATA}: the data files will not be installed"
+  )
+else()
+  set(SSM_DATA "${PROJECT_BINARY_DIR}/ssm-data")
+
+  include(ExternalProject)
+  ExternalProject_Add(
+    rte-examples-data
+    GIT_REPOSITORY https://github.com/earth-system-radiation/ssm-data.git
+    GIT_TAG "main"
+    GIT_SHALLOW True
+    EXCLUDE_FROM_ALL True
+    PREFIX ssm-data-cmake
+    SOURCE_DIR ${SSM_DATA}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+  )
+
+  set(fetch_ssm_data_command
+      ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config "$<CONFIG>"
+      --target ssm-data
+  )
+
+  add_test(NAME fetch_ssm_data COMMAND ${fetch_ssm_data_command})
+
+  install(CODE "execute_process(COMMAND ${fetch_ssm_data_command})")
+  install(
+    FILES # cmake-format: sort
+          ${SSM_DATA}/ssm-lw-ckdmip.nc
+          ${SSM_DATA}/ssm-lw-rce.nc
+          ${SSM_DATA}/ssm-lw-rfmip.nc
+          ${SSM_DATA}/ssm-sw-ckdmip.nc
+          ${SSM_DATA}/ssm-sw-rce.nc
+          ${SSM_DATA}/ssm-sw-rfmip.nc
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
+  )
+endif()

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -61,15 +61,17 @@ if(RTE_BUILD_TESTING)
 
     add_test(NAME fetch_ssm_data COMMAND ${fetch_ssm_data_command})
 
+    set(REF_DIR examples/rte-examples/reference)
+
     install(CODE "execute_process(COMMAND ${fetch_ssm_data_command})")
     install(
       FILES # cmake-format: sort
-            ${SSM_DATA}/ssm-lw-ckdmip.nc
-            ${SSM_DATA}/ssm-lw-rce.nc
-            ${SSM_DATA}/ssm-lw-rfmip.nc
-            ${SSM_DATA}/ssm-sw-ckdmip.nc
-            ${SSM_DATA}/ssm-sw-rce.nc
-            ${SSM_DATA}/ssm-sw-rfmip.nc
+            ${SSM_DATA}/${REF_DIR}/ssm-lw-ckdmip.nc
+            ${SSM_DATA}/${REF_DIR}/ssm-lw-rce.nc
+            ${SSM_DATA}/${REF_DIR}/ssm-lw-rfmip.nc
+            ${SSM_DATA}/${REF_DIR}/ssm-sw-ckdmip.nc
+            ${SSM_DATA}/${REF_DIR}/ssm-sw-rce.nc
+            ${SSM_DATA}/${REF_DIR}/ssm-sw-rfmip.nc
       DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
     )
   endif()

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -41,7 +41,7 @@ else()
 
   include(ExternalProject)
   ExternalProject_Add(
-    rte-examples-data
+    ssm-data
     GIT_REPOSITORY https://github.com/earth-system-radiation/ssm-data.git
     GIT_TAG "main"
     GIT_SHALLOW True

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -30,45 +30,49 @@ install(TARGETS ssm EXPORT rte-rrtmgp-targets)
 #
 # Fetch the rte-examples atmospheric state data
 #
-if(SSM_DATA)
-  add_test(NAME fetch_ssm_data COMMAND ${CMAKE_COMMAND} -E true)
-  message(
-    NOTICE
-    "Using an external dataset from ${SSM_DATA}: the data files will not be installed"
-  )
-else()
-  set(SSM_DATA "${PROJECT_BINARY_DIR}/ssm-data")
+if(RTE_BUILD_TESTING)
+  if(SSM_DATA)
+    add_test(NAME fetch_ssm_data COMMAND ${CMAKE_COMMAND} -E true)
+    message(
+      NOTICE
+      "Using an external dataset from ${SSM_DATA}: the data files will not be installed"
+    )
+  else()
+    set(SSM_DATA "${PROJECT_BINARY_DIR}/ssm-data")
 
-  include(ExternalProject)
-  ExternalProject_Add(
-    ssm-data
-    GIT_REPOSITORY https://github.com/earth-system-radiation/ssm-data.git
-    GIT_TAG "main"
-    GIT_SHALLOW True
-    EXCLUDE_FROM_ALL True
-    PREFIX ssm-data-cmake
-    SOURCE_DIR ${SSM_DATA}
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-  )
+    include(ExternalProject)
+    ExternalProject_Add(
+      ssm-data
+      GIT_REPOSITORY https://github.com/earth-system-radiation/ssm-data.git
+      GIT_TAG "main"
+      GIT_SHALLOW True
+      EXCLUDE_FROM_ALL True
+      PREFIX ssm-data-cmake
+      SOURCE_DIR ${SSM_DATA}
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      INSTALL_COMMAND ""
+    )
 
-  set(fetch_ssm_data_command
-      ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config "$<CONFIG>"
-      --target ssm-data
-  )
+    set(fetch_ssm_data_command
+        ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config "$<CONFIG>"
+        --target ssm-data
+    )
 
-  add_test(NAME fetch_ssm_data COMMAND ${fetch_ssm_data_command})
+    add_test(NAME fetch_ssm_data COMMAND ${fetch_ssm_data_command})
 
-  install(CODE "execute_process(COMMAND ${fetch_ssm_data_command})")
-  install(
-    FILES # cmake-format: sort
-          ${SSM_DATA}/ssm-lw-ckdmip.nc
-          ${SSM_DATA}/ssm-lw-rce.nc
-          ${SSM_DATA}/ssm-lw-rfmip.nc
-          ${SSM_DATA}/ssm-sw-ckdmip.nc
-          ${SSM_DATA}/ssm-sw-rce.nc
-          ${SSM_DATA}/ssm-sw-rfmip.nc
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
-  )
+    install(CODE "execute_process(COMMAND ${fetch_ssm_data_command})")
+    install(
+      FILES # cmake-format: sort
+            ${SSM_DATA}/ssm-lw-ckdmip.nc
+            ${SSM_DATA}/ssm-lw-rce.nc
+            ${SSM_DATA}/ssm-lw-rfmip.nc
+            ${SSM_DATA}/ssm-sw-ckdmip.nc
+            ${SSM_DATA}/ssm-sw-rce.nc
+            ${SSM_DATA}/ssm-sw-rfmip.nc
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
+    )
+  endif()
+
+  set_tests_properties(fetch_ssm_data PROPERTIES FIXTURES_SETUP fetch_ssm_data)
 endif()

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -59,4 +59,16 @@ else()
   )
 
   add_test(NAME fetch_ssm_data COMMAND ${fetch_ssm_data_command})
+
+  install(CODE "execute_process(COMMAND ${fetch_ssm_data_command})")
+  install(
+    FILES # cmake-format: sort
+          ${SSM_DATA}/ssm-lw-ckdmip.nc
+          ${SSM_DATA}/ssm-lw-rce.nc
+          ${SSM_DATA}/ssm-lw-rfmip.nc
+          ${SSM_DATA}/ssm-sw-ckdmip.nc
+          ${SSM_DATA}/ssm-sw-rce.nc
+          ${SSM_DATA}/ssm-sw-rfmip.nc
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
+  )
 endif()

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -59,16 +59,4 @@ else()
   )
 
   add_test(NAME fetch_ssm_data COMMAND ${fetch_ssm_data_command})
-
-  install(CODE "execute_process(COMMAND ${fetch_ssm_data_command})")
-  install(
-    FILES # cmake-format: sort
-          ${SSM_DATA}/ssm-lw-ckdmip.nc
-          ${SSM_DATA}/ssm-lw-rce.nc
-          ${SSM_DATA}/ssm-lw-rfmip.nc
-          ${SSM_DATA}/ssm-sw-ckdmip.nc
-          ${SSM_DATA}/ssm-sw-rce.nc
-          ${SSM_DATA}/ssm-sw-rfmip.nc
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
-  )
 endif()


### PR DESCRIPTION
Having added solutions from the `rte-examples` problem to the `rrtmgp-data` repo and created a (very small!) `ssm-data` repo, this PR adds tests comparing solutions to those reference values. 