### PR TITLE
Move data download out of RTE_BUILD_TESTING guard and quiet CMake output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,57 +102,6 @@ exit(tuple(map(int, xarray.__version__.split('.'))) < (0, 12, 2))"
 
   find_package(NetCDF_Fortran REQUIRED)
 
-  if(RRTMGP_DATA)
-    add_test(NAME fetch_rrtmgp_data COMMAND ${CMAKE_COMMAND} -E true)
-    message(
-      NOTICE
-      "Using an external dataset from ${RRTMGP_DATA}: the data files will not be installed"
-    )
-  else()
-    set(RRTMGP_DATA "${PROJECT_BINARY_DIR}/rrtmgp-data")
-
-    include(ExternalProject)
-    # Fetched at build time (part of the default ALL target) so the data is
-    # present before install and before ctest.
-    ExternalProject_Add(
-      rrtmgp-data
-      URL https://github.com/earth-system-radiation/rrtmgp-data/archive/refs/tags/v1.9.1.tar.gz
-      PREFIX rrtmgp-data-cmake
-      SOURCE_DIR ${RRTMGP_DATA}
-      CONFIGURE_COMMAND ""
-      BUILD_COMMAND ""
-      INSTALL_COMMAND ""
-    )
-
-    # The build already fetched the data (rrtmgp-data is part of the ALL
-    # target). This fixture verifies the files are present before any test that
-    # needs them runs, and fails with an actionable message if the project was
-    # not built first.
-    add_test(
-      NAME fetch_rrtmgp_data
-      COMMAND
-        ${CMAKE_COMMAND} -D DATA_DIR=${RRTMGP_DATA} -D DATA_LABEL=RRTMGP -D
-        "DATA_FILES=rrtmgp-aerosols-merra-lw.nc;rrtmgp-aerosols-merra-sw.nc;rrtmgp-clouds-lw-bnd.nc;rrtmgp-clouds-sw-bnd.nc;rrtmgp-gas-lw-g128.nc;rrtmgp-gas-lw-g256.nc;rrtmgp-gas-sw-g112.nc;rrtmgp-gas-sw-g224.nc"
-        -P ${PROJECT_SOURCE_DIR}/cmake/CheckData.cmake
-    )
-
-    install(
-      FILES # cmake-format: sort
-            ${RRTMGP_DATA}/rrtmgp-aerosols-merra-lw.nc
-            ${RRTMGP_DATA}/rrtmgp-aerosols-merra-sw.nc
-            ${RRTMGP_DATA}/rrtmgp-clouds-lw-bnd.nc
-            ${RRTMGP_DATA}/rrtmgp-clouds-sw-bnd.nc
-            ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc
-            ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
-            ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc
-            ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
-      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
-    )
-  endif()
-
-  set_tests_properties(
-    fetch_rrtmgp_data PROPERTIES FIXTURES_SETUP fetch_rrtmgp_data
-  )
   add_subdirectory(rrtmgp/data-loading-examples)
   add_subdirectory(examples)
   add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ project(
   LANGUAGES Fortran
 )
 
+# Use extraction-time timestamps for URL-based ExternalProject downloads so
+# dependent steps re-run when the download URL changes (CMake >= 3.24).
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 option(RTE_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(RTE_BUILD_C_HEADERS "Build c headers" OFF)
 option(RTE_BUILD_TESTING "Build tests" OFF)

--- a/examples/rte-examples/CMakeLists.txt
+++ b/examples/rte-examples/CMakeLists.txt
@@ -37,6 +37,7 @@ else()
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
+    LOG_DOWNLOAD TRUE
   )
 
   # The build already fetched the data (rte-examples-data is part of the ALL

--- a/rrtmgp/CMakeLists.txt
+++ b/rrtmgp/CMakeLists.txt
@@ -1,2 +1,59 @@
 add_subdirectory(kernels)
 add_subdirectory(frontend)
+
+if(RRTMGP_DATA)
+  add_test(NAME fetch_rrtmgp_data COMMAND ${CMAKE_COMMAND} -E true)
+  message(
+    NOTICE
+    "Using an external dataset from ${RRTMGP_DATA}: the data files will not be installed"
+  )
+else()
+  set(RRTMGP_DATA "${PROJECT_BINARY_DIR}/rrtmgp-data")
+
+  include(ExternalProject)
+  # Fetched at build time (part of the default ALL target) so the data is
+  # present before install and before ctest.
+  ExternalProject_Add(
+    rrtmgp-data
+    URL https://github.com/earth-system-radiation/rrtmgp-data/archive/refs/tags/v1.9.1.tar.gz
+    PREFIX rrtmgp-data-cmake
+    SOURCE_DIR ${RRTMGP_DATA}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD TRUE
+  )
+
+  # The build already fetched the data (rrtmgp-data is part of the ALL
+  # target). This fixture verifies the files are present before any test that
+  # needs them runs, and fails with an actionable message if the project was
+  # not built first.
+  add_test(
+    NAME fetch_rrtmgp_data
+    COMMAND
+      ${CMAKE_COMMAND} -D DATA_DIR=${RRTMGP_DATA} -D DATA_LABEL=RRTMGP -D
+      "DATA_FILES=rrtmgp-aerosols-merra-lw.nc;rrtmgp-aerosols-merra-sw.nc;rrtmgp-clouds-lw-bnd.nc;rrtmgp-clouds-sw-bnd.nc;rrtmgp-gas-lw-g128.nc;rrtmgp-gas-lw-g256.nc;rrtmgp-gas-sw-g112.nc;rrtmgp-gas-sw-g224.nc"
+      -P ${PROJECT_SOURCE_DIR}/cmake/CheckData.cmake
+  )
+
+  install(
+    FILES # cmake-format: sort
+          ${RRTMGP_DATA}/rrtmgp-aerosols-merra-lw.nc
+          ${RRTMGP_DATA}/rrtmgp-aerosols-merra-sw.nc
+          ${RRTMGP_DATA}/rrtmgp-clouds-lw-bnd.nc
+          ${RRTMGP_DATA}/rrtmgp-clouds-sw-bnd.nc
+          ${RRTMGP_DATA}/rrtmgp-gas-lw-g128.nc
+          ${RRTMGP_DATA}/rrtmgp-gas-lw-g256.nc
+          ${RRTMGP_DATA}/rrtmgp-gas-sw-g112.nc
+          ${RRTMGP_DATA}/rrtmgp-gas-sw-g224.nc
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rte-rrtmgp/
+  )
+endif()
+
+set_tests_properties(
+  fetch_rrtmgp_data PROPERTIES FIXTURES_SETUP fetch_rrtmgp_data
+)
+
+# propagate the RRTMGP_DATA variable to the parent scope so that the 
+# sibling subdirectories (examples, tests) can inherit it
+set(RRTMGP_DATA "${RRTMGP_DATA}" PARENT_SCOPE)

--- a/rrtmgp/CMakeLists.txt
+++ b/rrtmgp/CMakeLists.txt
@@ -24,10 +24,10 @@ else()
     LOG_DOWNLOAD TRUE
   )
 
-  # The build already fetched the data (rrtmgp-data is part of the ALL
-  # target). This fixture verifies the files are present before any test that
-  # needs them runs, and fails with an actionable message if the project was
-  # not built first.
+  # The build already fetched the data (rrtmgp-data is part of the ALL target).
+  # This fixture verifies the files are present before any test that needs them
+  # runs, and fails with an actionable message if the project was not built
+  # first.
   add_test(
     NAME fetch_rrtmgp_data
     COMMAND
@@ -54,6 +54,9 @@ set_tests_properties(
   fetch_rrtmgp_data PROPERTIES FIXTURES_SETUP fetch_rrtmgp_data
 )
 
-# propagate the RRTMGP_DATA variable to the parent scope so that the 
-# sibling subdirectories (examples, tests) can inherit it
-set(RRTMGP_DATA "${RRTMGP_DATA}" PARENT_SCOPE)
+# propagate the RRTMGP_DATA variable to the parent scope so that the sibling
+# subdirectories (examples, tests) can inherit it
+set(RRTMGP_DATA
+    "${RRTMGP_DATA}"
+    PARENT_SCOPE
+)

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -56,14 +56,13 @@ else()
   set(REF_DIR examples/rte-examples/reference)
 
   # The build already fetched the data (ssm-data is part of the ALL target).
-  # This fixture verifies the files are present before any test that needs
-  # them runs, and fails with an actionable message if the project was not
-  # built first.
+  # This fixture verifies the files are present before any test that needs them
+  # runs, and fails with an actionable message if the project was not built
+  # first.
   add_test(
     NAME fetch_ssm_data
     COMMAND
-      ${CMAKE_COMMAND} -D DATA_DIR=${SSM_DATA}/${REF_DIR} -D DATA_LABEL=SSM
-      -D
+      ${CMAKE_COMMAND} -D DATA_DIR=${SSM_DATA}/${REF_DIR} -D DATA_LABEL=SSM -D
       "DATA_FILES=ssm-lw-ckdmip.nc;ssm-lw-rce.nc;ssm-lw-rfmip.nc;ssm-sw-ckdmip.nc;ssm-sw-rce.nc;ssm-sw-rfmip.nc"
       -P ${PROJECT_SOURCE_DIR}/cmake/CheckData.cmake
   )
@@ -73,4 +72,7 @@ set_tests_properties(fetch_ssm_data PROPERTIES FIXTURES_SETUP fetch_ssm_data)
 
 # propagate the SSM_DATA variable to the parent scope so that the sibling
 # subdirectories (examples, tests) can inherit it
-set(SSM_DATA "${SSM_DATA}" PARENT_SCOPE)
+set(SSM_DATA
+    "${SSM_DATA}"
+    PARENT_SCOPE
+)

--- a/ssm/CMakeLists.txt
+++ b/ssm/CMakeLists.txt
@@ -30,44 +30,47 @@ install(TARGETS ssm EXPORT rte-rrtmgp-targets)
 #
 # Fetch the rte-examples atmospheric state data
 #
-if(RTE_BUILD_TESTING)
-  if(SSM_DATA)
-    add_test(NAME fetch_ssm_data COMMAND ${CMAKE_COMMAND} -E true)
-    message(
-      NOTICE
-      "Using an external dataset from ${SSM_DATA}: the data files will not be installed"
-    )
-  else()
-    set(SSM_DATA "${PROJECT_BINARY_DIR}/ssm-data")
+if(SSM_DATA)
+  add_test(NAME fetch_ssm_data COMMAND ${CMAKE_COMMAND} -E true)
+  message(
+    NOTICE
+    "Using an external dataset from ${SSM_DATA}: the data files will not be installed"
+  )
+else()
+  set(SSM_DATA "${PROJECT_BINARY_DIR}/ssm-data")
 
-    include(ExternalProject)
-    # Fetched at build time (part of the default ALL target) so the data is
-    # present before install and before ctest.
-    ExternalProject_Add(
-      ssm-data
-      URL https://github.com/earth-system-radiation/ssm-data/archive/refs/tags/v0.0.1.tar.gz
-      PREFIX ssm-data-cmake
-      SOURCE_DIR ${SSM_DATA}
-      CONFIGURE_COMMAND ""
-      BUILD_COMMAND ""
-      INSTALL_COMMAND ""
-    )
+  include(ExternalProject)
+  # Fetched at build time (part of the default ALL target) so the data is
+  # present before install and before ctest.
+  ExternalProject_Add(
+    ssm-data
+    URL https://github.com/earth-system-radiation/ssm-data/archive/refs/tags/v0.0.1.tar.gz
+    PREFIX ssm-data-cmake
+    SOURCE_DIR ${SSM_DATA}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD TRUE
+  )
 
-    set(REF_DIR examples/rte-examples/reference)
+  set(REF_DIR examples/rte-examples/reference)
 
-    # The build already fetched the data (ssm-data is part of the ALL target).
-    # This fixture verifies the files are present before any test that needs
-    # them runs, and fails with an actionable message if the project was not
-    # built first.
-    add_test(
-      NAME fetch_ssm_data
-      COMMAND
-        ${CMAKE_COMMAND} -D DATA_DIR=${SSM_DATA}/${REF_DIR} -D DATA_LABEL=SSM
-        -D
-        "DATA_FILES=ssm-lw-ckdmip.nc;ssm-lw-rce.nc;ssm-lw-rfmip.nc;ssm-sw-ckdmip.nc;ssm-sw-rce.nc;ssm-sw-rfmip.nc"
-        -P ${PROJECT_SOURCE_DIR}/cmake/CheckData.cmake
-    )
-  endif()
-
-  set_tests_properties(fetch_ssm_data PROPERTIES FIXTURES_SETUP fetch_ssm_data)
+  # The build already fetched the data (ssm-data is part of the ALL target).
+  # This fixture verifies the files are present before any test that needs
+  # them runs, and fails with an actionable message if the project was not
+  # built first.
+  add_test(
+    NAME fetch_ssm_data
+    COMMAND
+      ${CMAKE_COMMAND} -D DATA_DIR=${SSM_DATA}/${REF_DIR} -D DATA_LABEL=SSM
+      -D
+      "DATA_FILES=ssm-lw-ckdmip.nc;ssm-lw-rce.nc;ssm-lw-rfmip.nc;ssm-sw-ckdmip.nc;ssm-sw-rce.nc;ssm-sw-rfmip.nc"
+      -P ${PROJECT_SOURCE_DIR}/cmake/CheckData.cmake
+  )
 endif()
+
+set_tests_properties(fetch_ssm_data PROPERTIES FIXTURES_SETUP fetch_ssm_data)
+
+# propagate the SSM_DATA variable to the parent scope so that the sibling
+# subdirectories (examples, tests) can inherit it
+set(SSM_DATA "${SSM_DATA}" PARENT_SCOPE)


### PR DESCRIPTION
## Summary

Follow-up refinements to the data-fetching setup. Three focused changes:

1. Opt into CMake policy `CMP0135` to silence the URL-download timestamp warning.
2. Reduce build-time console noise from the archive download/extract step.
3. Move the RRTMGP and SSM data fetch/install out of the `RTE_BUILD_TESTING` guard and into their own subdirectories, so scheme data is acquired and installed regardless of whether tests are enabled.


## Details

### Silence CMP0135 warning
URL-based `ExternalProject_Add` downloads emit a `CMP0135` developer warning on CMake >= 3.24. Set the policy to `NEW` (extraction-time timestamps) once at the top of the root `CMakeLists.txt`, guarded by `if(POLICY CMP0135)` so it is a no-op on older CMake (project minimum is still 3.18).

### Quiet the build output
Add `LOG_DOWNLOAD TRUE` to the `ExternalProject_Add` calls so that the verbose download/extract status is written to a log file rather than the console (CMake still prints the log automatically on failure).

### Move data fetch outside the testing guard
Previously, the `rrtmgp-data` fetch/install lived in the root `CMakeLists.txt` inside `if(RTE_BUILD_TESTING)`, meaning scheme data was only fetched/installed when tests were enabled. Scheme data is a runtime dependency of the library, so:

- Move the `rrtmgp-data` block into `rrtmgp/CMakeLists.txt`.
- Move the `ssm-data` block out of its `RTE_BUILD_TESTING` guard in `ssm/CMakeLists.txt`.
- Propagate `RRTMGP_DATA` / `SSM_DATA` to the parent scope via `PARENT_SCOPE` so sibling subdirectories (`examples`, `tests`) inherit the resolved value.

